### PR TITLE
Small corrections to docs generation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=
-SPHINXBUILD   ?= sphinx-build
+SPHINXBUILD   ?= poetry run sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -238,4 +238,4 @@ def linkcode_resolve(domain, info):
     if tag != "master":
         tag = f"v{ipumspy.__version__}"
 
-    return f"https://github.com/ipums/ipumspy/blob/{tag}/pandera/{fn}{linespec}"
+    return f"https://github.com/ipums/ipumspy/blob/{tag}/src/ipumspy/{fn}{linespec}"


### PR DESCRIPTION
Explicitly forcing docs generation to call `poetry` in the `Makefile` and actually getting the `[source]` links correct.