### PR TITLE
Add more python versions to test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,5 +49,6 @@ jobs:
 
       - name: Run tests
         env:
+          # now has creds to run integration tests
           IPUMS_API_KEY: ${{ secrets.IPUMS_API_KEY }}
         run: poetry run py.test --runint


### PR DESCRIPTION
Currently, only 3.7 is tested, but we should really also test 3.8, 3.9, and 3.10. This just adds those tests in.