### PR TITLE
Make wait for extract double its time

### DIFF
--- a/src/ipumspy/api/core.py
+++ b/src/ipumspy/api/core.py
@@ -306,7 +306,7 @@ class IpumsApiClient:
             elif status != "completed":
                 time.sleep(wait_time)
                 total_time += wait_time
-                wait_time = max(wait_time * 2, max_wait_time)
+                wait_time = min(wait_time * 2, max_wait_time)
             else:
                 break
 

--- a/tests/mock_api.py
+++ b/tests/mock_api.py
@@ -1,5 +1,7 @@
 import os
-from typing import Dict, Optional
+from asyncio import Lock
+from datetime import datetime, timedelta
+from typing import Dict
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request
@@ -8,6 +10,22 @@ from pydantic import BaseModel
 load_dotenv(".env.test")
 
 app = FastAPI()
+
+
+class Counter:
+    def __init__(self):
+        self.val = 10
+        self.lock = Lock()
+
+    async def get_and_increment(self) -> int:
+        async with self.lock:
+            val = self.val
+            self.val += 1
+            return val
+
+
+counter = Counter()
+db = {}
 
 
 class ExtractSpec(BaseModel):
@@ -24,7 +42,25 @@ async def submit_extract(
 ):
     if request.headers["Authorization"] != os.environ.get("IPUMS_API_KEY"):
         raise HTTPException(403, "Incorrect api key")
-    return {"number": 10}
+
+    number = await counter.get_and_increment()
+    db[number] = datetime.utcnow()
+    return {"number": number}
+
+
+@app.get("/extracts/{extract_id}")
+async def download_extract(extract_id: int, request: Request):
+    if request.headers["Authorization"] != os.environ.get("IPUMS_API_KEY"):
+        raise HTTPException(403, "Incorrect api key")
+
+    if extract_id in db:
+        if datetime.utcnow() - db[extract_id] > timedelta(seconds=3):
+            return {
+                "status": "completed",
+            }
+        else:
+            return {"status": "started"}
+    raise HTTPException(404, "Not found")
 
 
 @app.get("/extracts")


### PR DESCRIPTION
wait_for_extract can actually wait quite a long time with the default
parameters, in particular, up to 5 minutes it can sleep. It often
_shouldn't_ do this. However, due to an errant `max` instead of `min`,
it was _always_ waiting 5 minutes anytime something other than
"completed" was returned from the API.

This commit fixes that typo and extends the `sumbit_extract` test to
also test `wait_for_extract`.