### PR TITLE
Build and push docs to github pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,3 +52,13 @@ jobs:
           # now has creds to run integration tests
           IPUMS_API_KEY: ${{ secrets.IPUMS_API_KEY }}
         run: poetry run py.test --runint
+      
+      - name: Build docs
+        run: cd docs && poetry run make html
+      
+      - name: Push docs
+        if: github.ref == 'refs/heads/master'
+        uses: JamesIves/github-pages-deploy-action@4.1.6
+        with:
+          branch: gh-pages
+          folder: docs/_build/html


### PR DESCRIPTION
As an alternative to readthedocs (mostly because I can't see that build), just push docs to github pages hosted at this repo. The URL would then be:

https://ipums.github.io/ipumspy