### PR TITLE
tweak path again

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ from sphinx.util import logging
 
 import ipumspy
 
-sys.path.insert(0, os.path.abspath("../../src/ipumspy"))
+sys.path.insert(0, os.path.abspath("../../src"))
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
`import ipumspy` is still causing build failure. If I don't `import ipumspy` and hardcode all references to it below in `conf.py` the docs do build successfully on rtd, but none of the auto doc stuff shows up.