### PR TITLE
Add cps support

### DIFF
--- a/docs/source/change-log.rst
+++ b/docs/source/change-log.rst
@@ -16,8 +16,9 @@ This project adheres to `Semantic Versioning`_.
 year-month-day
 
 * Added :py:meth:`~ipumspy.api.extract.extract_to_dict()` method to enable easy exporting of extract objects to dictionary objects for eventual writing to .json for ease of extract sharing.
-* Added :py:meth:`~ipumspy.api.exceptions.IpumsExtractNotSubmitted` exception
+* Added :py:meth:`~ipumspy.api.exceptions.IpumsExtractNotSubmitted` exception. This will be raised when attempting to retrieve an extract id or download link from a extract that has not been submitted to the IPUMS extract engine.
 * Added ability to download Stata, SPSS, SAS, and R command files with data files :py:meth:`~ipumspy.api.IpumsApiClient.download_extract()`.
+* Added support for IPUMS CPS extracts with :py:class:`~ipumspy.api.extract.CpsExtract`
 * New minimum python version: Python 3.7.1 
 
 0.1.0

--- a/docs/source/extracts.rst
+++ b/docs/source/extracts.rst
@@ -35,11 +35,15 @@ filled in as new IPUMS data collections become accessible via API.
       - usa
       - `usa samples <https://usa.ipums.org/usa-action/samples/sample_ids>`__
       - `usa variables <https://usa.ipums.org/usa-action/variables/group>`__
+    * - IPUMS CPS
+      - cps
+      - `cps samples <https://cps.ipums.org/cps-action/samples/sample_ids>`__
+      - `cps variables <https://cps.ipums.org/cps-action/variables/group>`__
 
 Extract Objects
 ---------------
 
-Each IPUMS data collection that is accessible via API (currently just IPUMS USA) has its own extract class.
+Each IPUMS data collection that is accessible via API (currently just IPUMS USA and IPUMS CPS) has its own extract class.
 Using this class to create your extract object obviates the need to specify a data collection.
 
 For example:
@@ -157,7 +161,7 @@ returns:
 Unsupported Features
 --------------------
 
-Not all reatures available through the IPUMS extract web UI are currently supported for extracts made via API. 
+Not all features available through the IPUMS extract web UI are currently supported for extracts made via API. 
 For a list of currently unsupported features, see `the developer documentation <https://beta.developer.ipums.org/docs/apiprogram/apis/usa/>`__.
 This list will be updated as more features become available.
 

--- a/docs/source/reference/api.rst
+++ b/docs/source/reference/api.rst
@@ -30,6 +30,7 @@ extract class.
    ipumspy.api.BaseExtract
    ipumspy.api.OtherExtract
    ipumspy.api.UsaExtract
+   ipumspy.api.CpsExtract
 
 Importing or Exporting Extract Definitions
 ------------------------------------------

--- a/src/ipumspy/api/extract.py
+++ b/src/ipumspy/api/extract.py
@@ -111,7 +111,7 @@ class UsaExtract(BaseExtract, collection="usa"):
         self,
         samples: List[str],
         variables: List[str],
-        description: str = "My IPUMS extract",
+        description: str = "My IPUMS USA extract",
         data_format: str = "fixed_width",
         **kwargs,
     ):
@@ -138,6 +138,60 @@ class UsaExtract(BaseExtract, collection="usa"):
 
     @classmethod
     def from_api_response(cls, api_response: Dict[str, Any]) -> UsaExtract:
+        return cls(
+            samples=list(api_response["samples"]),
+            variables=list(api_response["variables"]),
+            data_format=api_response["data_format"],
+            description=api_response["description"],
+        )
+
+    def build(self) -> Dict[str, Any]:
+        """
+        Convert the object into a dictionary to be passed to the IPUMS API
+        as a JSON string
+        """
+        return {
+            "description": self.description,
+            "data_format": self.data_format,
+            "data_structure": {"rectangular": {"on": "P"}},
+            "samples": {sample: {} for sample in self.samples},
+            "variables": {variable.upper(): {} for variable in self.variables},
+            "collection": self.collection,
+        }
+
+
+class CpsExtract(BaseExtract, collection="cps"):
+    def __init__(
+        self,
+        samples: List[str],
+        variables: List[str],
+        description: str = "My IPUMS CPS extract",
+        data_format: str = "fixed_width",
+        **kwargs,
+    ):
+        """
+        Defining an IPUMS CPS extract.
+
+        Args:
+            samples: list of IPUMS CPS sample IDs
+            variables: list of IPUMS CPS variable names
+            description: short description of your extract
+            data_format: fixed_width and csv supported
+        """
+
+        super().__init__()
+        self.samples = samples
+        self.variables = variables
+        self.description = description
+        self.data_format = data_format
+        self.collection = self.collection
+        """Name of an IPUMS data collection"""
+
+        # check kwargs for conflicts with defaults
+        self._kwarg_warning(kwargs)
+
+    @classmethod
+    def from_api_response(cls, api_response: Dict[str, Any]) -> CpsExtract:
         return cls(
             samples=list(api_response["samples"]),
             variables=list(api_response["variables"]),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,7 @@ from ipumspy.api import (
     IpumsApiClient,
     OtherExtract,
     UsaExtract,
+    CpsExtract,
     extract_from_dict,
     extract_to_dict,
 )
@@ -71,9 +72,28 @@ def test_usa_build_extract():
         "data_structure": {"rectangular": {"on": "P"}},
         "samples": {"us2012b": {}},
         "variables": {"AGE": {}, "SEX": {}},
-        "description": "My IPUMS extract",
+        "description": "My IPUMS USA extract",
         "data_format": "fixed_width",
         "collection": "usa",
+    }
+
+
+def test_cps_build_extract():
+    """
+    Confirm that test extract formatted correctly
+    """
+    extract = CpsExtract(
+        ["cps2012_03b"],
+        ["AGE", "SEX"],
+    )
+    assert extract.collection == "cps"
+    assert extract.build() == {
+        "data_structure": {"rectangular": {"on": "P"}},
+        "samples": {"cps2012_03b": {}},
+        "variables": {"AGE": {}, "SEX": {}},
+        "description": "My IPUMS CPS extract",
+        "data_format": "fixed_width",
+        "collection": "cps",
     }
 
 


### PR DESCRIPTION
Added `CpsExtract` class. Currently CPS and USA extract functionality are identical. Added tests and updated documentation with links to CPS sample id and variable name info.