### PR TITLE
Fix bs4 specification

### DIFF
--- a/docs/source/change-log.rst
+++ b/docs/source/change-log.rst
@@ -11,6 +11,12 @@ This project adheres to `Semantic Versioning`_.
 .. _Semantic Versioning: http://semver.org/
 
 
+0.2.1
+-----
+2022-05-23
+
+* Update requirement to beautifulsoup4 instead of bs4
+
 0.2.0
 -----
 2022-05-20

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -16,6 +16,12 @@ Install with ``pip``:
 
     pip install ipumspy
 
+Install with ``conda``:
+
+.. code:: bash
+    
+    conda install ipumspy
+
 Read an IPUMS extract
 ---------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ pyarrow = "^3.0.0"
 requests = "^2.25.1"
 importlib-metadata = {version = "^4.0.1", python = "<3.8"}
 PyYAML = "^5.4.1"
-bs4 = "^0.0.1"
+beautifulsoup4 = "^4.11.1"
 
 # Documentation dependencies
 # Note that these are currently required to be specified in this section

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ipumspy"
-version = "0.2.0"
+version = "0.2.1"
 description = "A collection of tools for working with IPUMS data"
 authors = ["Kevin H. Wilson <kevin_wilson@brown.edu>",
            "Renae Rodgers <rodge103@umn.edu>"]

--- a/src/ipumspy/api/extract.py
+++ b/src/ipumspy/api/extract.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import warnings
 from typing import Any, Dict, List, Optional, Type, Union
 
-import bs4
 import requests
 import json
 


### PR DESCRIPTION
Having bs4 in the requirements section of the pyproject.toml was causing problems for the conda recipe / build; updating this to beautifulsoup4 should fix this.