### PR TITLE
Attach characteristics

### DIFF
--- a/src/ipumspy/api/extract.py
+++ b/src/ipumspy/api/extract.py
@@ -175,10 +175,9 @@ class BaseExtract:
                     f"Expected a string or Variable object; {type(variable)} received."
                 )
 
-
     def attach_characteristics(self, variable: Union[Variable, str], of: List[str]):
         """
-        A method to update existing Variable objects or create Variable objects
+        A method to update existing IPUMS Extract Variable objects 
         with the IPUMS attach characteristics feature.
 
         Args:
@@ -193,6 +192,37 @@ class BaseExtract:
                  value of the `of` argument
         """
         self._update_variable_feature(variable, "attached_characteristics", of)
+
+    def add_data_quality_flags(self, variable: Union[Variable, str]):
+        """
+        A method to update existing IPUMS Extract Variable objects to include that
+        variable's data quality flag in the extract if it exists.
+
+        Args:
+            variable: a Variable object or a string variable name
+
+        Returns: A Variable object with the `data_quality_fags` attribute set to True
+        """
+        self._update_variable_feature(variable, "data_quality_flags", True)
+
+    def select_cases(self, variable: Union[Variable, str], values: List[Union[int, str]], general: bool=True):
+        """
+        A method to update existing IPUMS Extract Variable objects to select cases
+        with the specified values of that IPUMS variable.
+
+        Args:
+            variable: a Variable object or a string variable name
+            values: a list of values for which to select records
+            general: set to False to select cases on detailed codes. Defaults to True.
+
+        Returns: A Variable object with the `select_cases` attribute with general or detailed codes specified for selection.
+        """
+        # stringify values
+        values = [str(v) for v in values]
+        if general:
+            self._update_variable_feature(variable, "case_selections", {"general": values})
+        else:
+            self._update_variable_feature(variable, "case_selections", {"detailed": values})
     
 
 class OtherExtract(BaseExtract, collection="other"):

--- a/src/ipumspy/api/extract.py
+++ b/src/ipumspy/api/extract.py
@@ -43,7 +43,7 @@ class Variable:
             setattr(self, attribute, value)
         else:
             raise KeyError(f"Variable has no attribute '{attribute}'.")
-        
+
     def build(self):
         built_var = self.__dict__.copy()
         # don't repeat the variable name
@@ -165,7 +165,7 @@ class BaseExtract:
         # if no api_version is specified, use default IpumsApiClient version
         else:
             return self.api_version
-        
+
     def attach_characteristics(self, variable: Union[Variable, str], of: List[str]):
         if isinstance(variable, Variable):
             variable.update("attached_characteristics", of)
@@ -177,7 +177,9 @@ class BaseExtract:
             else:
                 raise ValueError(f"{variable} is not part of this extract.")
         else:
-            raise TypeError(f"Expected a string or Variable object; {type(variable)} received.")
+            raise TypeError(
+                f"Expected a string or Variable object; {type(variable)} received."
+            )
 
 
 class OtherExtract(BaseExtract, collection="other"):
@@ -263,7 +265,9 @@ class UsaExtract(BaseExtract, collection="usa"):
             "dataFormat": self.data_format,
             "dataStructure": {"rectangular": {"on": "P"}},
             "samples": {sample.id: {} for sample in self.samples},
-            "variables": {variable.name.upper(): variable.build() for variable in self.variables},
+            "variables": {
+                variable.name.upper(): variable.build() for variable in self.variables
+            },
             "collection": self.collection,
             "version": self.api_version,
         }
@@ -332,7 +336,9 @@ class CpsExtract(BaseExtract, collection="cps"):
             "dataFormat": self.data_format,
             "dataStructure": {"rectangular": {"on": "P"}},
             "samples": {sample.id: {} for sample in self.samples},
-            "variables": {variable.name.upper(): {} for variable in self.variables},
+            "variables": {
+                variable.name.upper(): variable.build() for variable in self.variables
+            },
             "collection": self.collection,
             "version": self.api_version,
         }

--- a/src/ipumspy/api/extract.py
+++ b/src/ipumspy/api/extract.py
@@ -32,12 +32,6 @@ class Variable:
     attached_characteristics: Optional[List[str]] = field(default_factory=list)
     data_quality_flags: Optional[bool] = False
 
-    @classmethod
-    def from_name(cls, name: str) -> Variable:
-        return cls(
-            name=name,
-        )
-
     def update(self, attribute: str, value: Any):
         if hasattr(self, attribute):
             setattr(self, attribute, value)
@@ -59,17 +53,11 @@ class Variable:
 class Sample:
     id: str
 
-    @classmethod
-    def from_id(cls, id: str) -> Sample:
-        return cls(
-            id=id,
-        )
-
     def update(self, attribute: str, value: Any):
         if hasattr(self, attribute):
             setattr(self, attribute, value)
         else:
-            raise KeyError(f"Variable has no attribute '{attribute}'.")
+            raise KeyError(f"Sample has no attribute '{attribute}'.")
 
 
 class BaseExtract:

--- a/src/ipumspy/api/extract.py
+++ b/src/ipumspy/api/extract.py
@@ -161,6 +161,21 @@ class BaseExtract:
             return self.api_version
 
     def attach_characteristics(self, variable: Union[Variable, str], of: List[str]):
+        """
+        A method to update existing Variable objects or create Variable objects
+        with the IPUMS attach characteristics feature.
+
+        Args:
+            variable: a Variable object or a string variable name
+            of: a list of records for which to create a variable on the individual record.
+                Allowable values include "mother", "father", "spouse", "head". For IPUMS
+                collection that identify same sex couples can also accept "mother2" and "father2"
+                values in this list. If either "<parent>" or "<parent>2" values are included,
+                their same sex counterpart will automatically be included in the extract.
+
+        Returns: A Variable object with the `attached_characteristics` attribute with the 
+                 value of the `of` argument
+        """
         if isinstance(variable, Variable):
             variable.update("attached_characteristics", of)
         elif isinstance(variable, str):

--- a/src/ipumspy/api/extract.py
+++ b/src/ipumspy/api/extract.py
@@ -159,6 +159,22 @@ class BaseExtract:
         # if no api_version is specified, use default IpumsApiClient version
         else:
             return self.api_version
+        
+    def _update_variable_feature(self, variable, feature, specification):
+            if isinstance(variable, Variable):
+                variable.update(feature, specification)
+            elif isinstance(variable, str):
+                for var in self.variables:
+                    if var.name == variable:
+                        var.update(feature, specification)
+                        break
+                else:
+                    raise ValueError(f"{variable} is not part of this extract.")
+            else:
+                raise TypeError(
+                    f"Expected a string or Variable object; {type(variable)} received."
+                )
+
 
     def attach_characteristics(self, variable: Union[Variable, str], of: List[str]):
         """
@@ -176,20 +192,8 @@ class BaseExtract:
         Returns: A Variable object with the `attached_characteristics` attribute with the 
                  value of the `of` argument
         """
-        if isinstance(variable, Variable):
-            variable.update("attached_characteristics", of)
-        elif isinstance(variable, str):
-            for var in self.variables:
-                if var.name == variable:
-                    var.update("attached_characteristics", of)
-                    break
-            else:
-                raise ValueError(f"{variable} is not part of this extract.")
-        else:
-            raise TypeError(
-                f"Expected a string or Variable object; {type(variable)} received."
-            )
-
+        self._update_variable_feature(variable, "attached_characteristics", of)
+    
 
 class OtherExtract(BaseExtract, collection="other"):
     def __init__(self, collection: str, details: Optional[Dict[str, Any]]):

--- a/src/ipumspy/api/extract.py
+++ b/src/ipumspy/api/extract.py
@@ -32,6 +32,9 @@ class Variable:
     attached_characteristics: Optional[List[str]] = field(default_factory=list)
     data_quality_flags: Optional[bool] = False
 
+    def __post_init__(self):
+        self.name = self.name.upper()
+
     def update(self, attribute: str, value: Any):
         if hasattr(self, attribute):
             setattr(self, attribute, value)
@@ -52,6 +55,9 @@ class Variable:
 @dataclass
 class Sample:
     id: str
+
+    def __post_init__(self):
+        self.id = self.id.lower()
 
     def update(self, attribute: str, value: Any):
         if hasattr(self, attribute):

--- a/tests/cassettes/test_api/test_usa_feature_errors.yaml
+++ b/tests/cassettes/test_api/test_usa_feature_errors.yaml
@@ -1,0 +1,201 @@
+interactions:
+- request:
+    body: '{"description": "My IPUMS USA extract", "dataFormat": "fixed_width", "dataStructure":
+      {"rectangular": {"on": "P"}}, "samples": {"us2012b": {}}, "variables": {"AGE":
+      {"preselected": false, "caseSelections": {"general": ["200"]}, "attachedCharacteristics":
+      [], "dataQualityFlags": false}, "SEX": {"preselected": false, "caseSelections":
+      {}, "attachedCharacteristics": [], "dataQualityFlags": false}, "RACE": {"preselected":
+      false, "caseSelections": {}, "attachedCharacteristics": [], "dataQualityFlags":
+      false}}, "collection": "usa", "version": 2}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '545'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-ipumspy:0.2.2a0.github.com/ipums/ipumspy
+    method: POST
+    uri: https://api.ipums.org/extracts?collection=usa&version=2
+  response:
+    body:
+      string: '{"type":"SemanticValidationError","status":{"code":400,"name":"Bad
+        Request"},"detail":["Invalid general case selection of 200 for variable AGE"]}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '145'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Mar 2023 16:48:57 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx/1.18.0
+      Vary:
+      - Origin
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Ratelimit-Limit:
+      - '-1'
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Reset:
+      - '0'
+      X-Request-Id:
+      - f0a03074-a613-4f28-95c7-dab8a1b4ee9c
+      X-Runtime:
+      - '0.402650'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 400
+      message: Bad Request
+- request:
+    body: '{"description": "My IPUMS USA extract", "dataFormat": "fixed_width", "dataStructure":
+      {"rectangular": {"on": "P"}}, "samples": {"us2012b": {}}, "variables": {"AGE":
+      {"preselected": false, "caseSelections": {}, "attachedCharacteristics": [],
+      "dataQualityFlags": false}, "SEX": {"preselected": false, "caseSelections":
+      {"detailed": ["100"]}, "attachedCharacteristics": [], "dataQualityFlags": false},
+      "RACE": {"preselected": false, "caseSelections": {}, "attachedCharacteristics":
+      [], "dataQualityFlags": false}}, "collection": "usa", "version": 2}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '546'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-ipumspy:0.2.2a0.github.com/ipums/ipumspy
+    method: POST
+    uri: https://api.ipums.org/extracts?collection=usa&version=2
+  response:
+    body:
+      string: '{"type":"SemanticValidationError","status":{"code":400,"name":"Bad
+        Request"},"detail":["Detailed case selection made but detailed variable not
+        found for SEX."]}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '160'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Mar 2023 16:48:58 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx/1.18.0
+      Vary:
+      - Origin
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Ratelimit-Limit:
+      - '-1'
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Reset:
+      - '0'
+      X-Request-Id:
+      - f98d00fa-87b4-4b47-8097-814176ad17d5
+      X-Runtime:
+      - '0.273791'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 400
+      message: Bad Request
+- request:
+    body: '{"description": "My IPUMS USA extract", "dataFormat": "fixed_width", "dataStructure":
+      {"rectangular": {"on": "P"}}, "samples": {"us2012b": {}}, "variables": {"AGE":
+      {"preselected": false, "caseSelections": {}, "attachedCharacteristics": [],
+      "dataQualityFlags": false}, "SEX": {"preselected": false, "caseSelections":
+      {}, "attachedCharacteristics": [], "dataQualityFlags": false}, "RACE": {"preselected":
+      false, "caseSelections": {"detailed": ["1"]}, "attachedCharacteristics": [],
+      "dataQualityFlags": false}}, "collection": "usa", "version": 2}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '544'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-ipumspy:0.2.2a0.github.com/ipums/ipumspy
+    method: POST
+    uri: https://api.ipums.org/extracts?collection=usa&version=2
+  response:
+    body:
+      string: '{"type":"SemanticValidationError","status":{"code":400,"name":"Bad
+        Request"},"detail":["Invalid detailed case selection of 001 for variable RACE"]}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Mar 2023 16:48:58 GMT
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx/1.18.0
+      Vary:
+      - Origin
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Ratelimit-Limit:
+      - '-1'
+      X-Ratelimit-Remaining:
+      - '0'
+      X-Ratelimit-Reset:
+      - '0'
+      X-Request-Id:
+      - f4ff6c02-f7e2-4ece-a08a-6a112e48335c
+      X-Runtime:
+      - '0.392526'
+      X-Xss-Protection:
+      - '0'
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -77,7 +77,20 @@ def test_usa_build_extract():
     assert extract.build() == {
         "dataStructure": {"rectangular": {"on": "P"}},
         "samples": {"us2012b": {}},
-        "variables": {"AGE": {}, "SEX": {}},
+        "variables": {
+            "AGE": {
+                "preselected": False,
+                "caseSelections": {},
+                "attachedCharacteristics": [],
+                "dataQualityFlags": False,
+            },
+            "SEX": {
+                "preselected": False,
+                "caseSelections": {},
+                "attachedCharacteristics": [],
+                "dataQualityFlags": False,
+            },
+        },
         "description": "My IPUMS USA extract",
         "dataFormat": "fixed_width",
         "collection": "usa",
@@ -97,7 +110,20 @@ def test_cps_build_extract():
     assert extract.build() == {
         "dataStructure": {"rectangular": {"on": "P"}},
         "samples": {"cps2012_03b": {}},
-        "variables": {"AGE": {}, "SEX": {}},
+        "variables": {
+            "AGE": {
+                "preselected": False,
+                "caseSelections": {},
+                "attachedCharacteristics": [],
+                "dataQualityFlags": False,
+            },
+            "SEX": {
+                "preselected": False,
+                "caseSelections": {},
+                "attachedCharacteristics": [],
+                "dataQualityFlags": False,
+            },
+        },
         "description": "My IPUMS CPS extract",
         "dataFormat": "fixed_width",
         "collection": "cps",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -98,6 +98,39 @@ def test_usa_build_extract():
     }
 
 
+def test_usa_attach_characteristics():
+    """
+    Confirm that attach_characteristics updates extract definition correctly
+    """
+    extract = UsaExtract(
+        ["us2012b"],
+        ["AGE", "SEX"],
+    )
+    extract.attach_characteristics("AGE", ["father"])
+    assert extract.build() == {
+        "dataStructure": {"rectangular": {"on": "P"}},
+        "samples": {"us2012b": {}},
+        "variables": {
+            "AGE": {
+                "preselected": False,
+                "caseSelections": {},
+                "attachedCharacteristics": ["father"],
+                "dataQualityFlags": False,
+            },
+            "SEX": {
+                "preselected": False,
+                "caseSelections": {},
+                "attachedCharacteristics": [],
+                "dataQualityFlags": False,
+            },
+        },
+        "description": "My IPUMS USA extract",
+        "dataFormat": "fixed_width",
+        "collection": "usa",
+        "version": None,
+    }
+
+
 def test_cps_build_extract():
     """
     Confirm that test extract formatted correctly

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -442,6 +442,7 @@ def test_extract_from_dict(fixtures_path: Path):
         # data structure not currently an extract attribute...
         # assert item.data_structure == "rectangular"
         assert item.data_format == "fixed_width"
+        assert item.api_version == 2
 
     # if an unsupported api version is specified
     # make sure NotImplementedError is raised


### PR DESCRIPTION
Add support for microdata extract features new in IPUMS API v2

1. attach characteristics
2. case selection
3. including data quality flags

Also, if an api version is specified in an extract definition read from a file, this version travels with the extract object.