### PR TITLE
update .readthedocs.yaml with correct support for poetry

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,20 +7,18 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.9"
   jobs:
     post_create_environment:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
-      - pip install poetry
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
+      - python -m pip install poetry
     post_install:
       # Install only dependencies including docs
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-      - poetry install --with docs
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py


### PR DESCRIPTION
Updated .readthedocs.yaml based on [this issue](https://github.com/readthedocs/readthedocs.org/issues/4912#issuecomment-1992286540) with support for poetry virtual environments to (hopefully) fix the readthedocs build failure.