### PR TITLE
Numpy fix

### DIFF
--- a/docs/source/change-log.rst
+++ b/docs/source/change-log.rst
@@ -17,7 +17,7 @@ This project adheres to `Semantic Versioning`_.
 
 * Bug Fixes
 
-  * Pinned a minimum required version for ``numpy`` to avoid v2.0.0 incompatability with ``pandas``.
+  * Pinned a minimum required version for ``numpy`` to avoid v2.0.0 incompatability with earlier versions of ``pandas`` when installing with pip.
 
 0.5.0
 -----

--- a/docs/source/change-log.rst
+++ b/docs/source/change-log.rst
@@ -11,6 +11,13 @@ This project adheres to `Semantic Versioning`_.
 .. _Semantic Versioning: http://semver.org/
 
 
+0.5.1
+-----
+2024-07-01
+
+* Bug Fixes
+
+  * Pinned a minimum required version for ``numpy`` to avoid v2.0.0 incompatability with ``pandas``.
 
 0.5.0
 -----

--- a/poetry.lock
+++ b/poetry.lock
@@ -2298,4 +2298,4 @@ docs = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "e937d6edba79affd414a8292691a01647e2b9080b83b8e3b9fefa982d2d8ac2b"
+content-hash = "cbb2237162133d2fcd62f84a7188b8b4107564affa74d9da0dd312d51bb68292"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ipumspy"
-version = "0.5.0"
+version = "0.5.1"
 description = "A collection of tools for working with IPUMS data"
 authors = ["Kevin H. Wilson <kevin_wilson@brown.edu>",
            "Renae Rodgers <rodge103@umn.edu>"]
@@ -12,6 +12,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.8"
 pandas = "^1.5.2"
+numpy = "^1.24.4"
 click = "^8.0.0"
 pyarrow = "^14.0.2"
 requests = {extras = ["use_chardet_on_py3"], version = "^2.26.0"}


### PR DESCRIPTION
This PR pins a minimum version of numpy to prevent a compatibility problem with older versions of pandas.

See this [SO post](https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from) for more.