### PR TITLE
Docs 0.6.0 tweaks

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -7,7 +7,7 @@
 Command Line Interface
 ======================
 
-``ipumspy`` allows you to interact with the IPUMS API via the command line. If you
+ipumspy allows you to interact with the IPUMS API via the command line. If you
 have :doc:`installed <getting_started>` with ``pip``, then you should have an ``ipums``
 command available on the command line.
 
@@ -17,14 +17,13 @@ You can explore what commands are available by running the ``--help`` option:
 
     ipums --help
 
-In particular, suppose that you have specified an extract in an ``ipums.yml`` file
-as described in the :doc:`getting started guide <getting_started>`.
+In particular, suppose that you have specified an extract in an ``ipums.yaml`` file
+as described in the :ref:`IPUMS API introduction <using-yaml>`.
 
 .. code:: yaml
 
     description: Simple IPUMS extract
     collection: usa
-    api_version: 2
     samples:
       - us2012b
     variables:
@@ -35,7 +34,7 @@ Then you can submit, wait for, and download the extract in a single line:
 
 .. code:: bash
 
-    ipums submit-and-download -k <IPUMS_API_KEY> ipums.yml
+    ipums submit-and-download -k <IPUMS_API_KEY> ipums.yaml
 
 Much of the rest of the functionality of the library is also available on the command
 line, as this document describes.
@@ -51,14 +50,13 @@ Specifying Multiple Extracts
 ****************************
 
 You may create mutliple files specifying extracts. For instance, in addition to the
-``ipums.yml`` described above, you might also have a file called ``ipums_with_race.yml``
+``ipums.yaml`` described above, you might also have a file called ``ipums_with_race.yaml``
 which contains the following:
 
 .. code:: yaml
 
     description: Another extract
     collection: usa
-    api_version: 2
     samples:
       - us2012b
     variables:
@@ -70,17 +68,16 @@ Then the following command would submit and download this extract:
 
 .. code:: bash
 
-    ipums submit-and-download -k <IPUMS_API_KEY> ipums_with_race.yml
+    ipums submit-and-download -k <IPUMS_API_KEY> ipums_with_race.yaml
 
 Alternatively, the ``submit-and-download`` command also allows you to specify *multiple*
-extracts simultaneously. To do so, specify the ``ipums_multiple.yml`` file as follows:
+extracts simultaneously. To do so, specify the ``ipums_multiple.yaml`` file as follows:
 
 .. code:: yaml
 
     extracts:
     - description: Simple IPUMS extract
       collection: usa
-      api_version: 2
       samples:
         - us2012b
       variables:
@@ -88,7 +85,6 @@ extracts simultaneously. To do so, specify the ``ipums_multiple.yml`` file as fo
         - SEX
     - description: Another extract
       collection: usa
-      api_version: 2
       samples:
         - us2012b
       variables:
@@ -102,7 +98,7 @@ command:
 
 .. code:: bash
 
-    ipums submit-and-download -k <IPUMS_API_KEY> ipums_multiple.yml
+    ipums submit-and-download -k <IPUMS_API_KEY> ipums_multiple.yaml
 
 Step-by-Step
 ************
@@ -114,7 +110,7 @@ functionlaity is available via the ``submit``, ``check``, and ``download`` comma
 
 .. code:: bash
 
-    ipums submit -k <IPUMS_API_KEY> ipums.yml
+    ipums submit -k <IPUMS_API_KEY> ipums.yaml
     # Your extract for collection usa has been successfully submitted with number 10
 
     ipums check -k <IPUMS_API_KEY> 10

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -54,12 +54,8 @@ project at the top of its website, which can be accessed from the `IPUMS homepag
 
 Once you're registered, you'll be able to create an `API key <https://account.ipums.org/api_keys>`__.
 
-For security reasons, we recommend storing your key in an environment variable rather than including it in your code:
+For security reasons, we recommend storing your key in an environment variable rather than including it in your code. The Conda documentation provides `instructions for saving environment variables <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables>`__ in conda environments for different operating systems. The example code on this page assumes that the API key is stored in an environment variable called "IPUMS_API_KEY."
 
-.. code:: python
-
-    import os
-    os.environ["IPUMS_API_KEY"] = "<your-api-key>"
 
 A Simple Example
 ****************

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -27,8 +27,10 @@ Install with ``conda``:
 Read an IPUMS extract
 ---------------------
 
-The following code parses an IPUMS extract DDI xml codebook and data file and returns a pandas data frame.
-Both fixed-width and csv files are supported.
+For microdata collections, ipumspy provides methods to parse DDI xml codebooks and load data files into 
+pandas ``DataFrame`` objects. Both fixed-width and csv files are supported.
+
+For example:
 
 .. code:: python
 
@@ -41,7 +43,7 @@ Both fixed-width and csv files are supported.
 IPUMS API Wrappers for Python
 -----------------------------
 
-``ipumspy`` provides an easy-to-use Python wrapper for IPUMS API endpoints.
+ipumspy provides an easy-to-use Python wrapper for IPUMS API endpoints.
 
 .. _get an api key:
 
@@ -54,8 +56,11 @@ project at the top of its website, which can be accessed from the `IPUMS homepag
 
 Once you're registered, you'll be able to create an `API key <https://account.ipums.org/api_keys>`__.
 
-For security reasons, we recommend storing your key in an environment variable rather than including it in your code. The Conda documentation provides `instructions for saving environment variables <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables>`__ in conda environments for different operating systems. The example code on this page assumes that the API key is stored in an environment variable called "IPUMS_API_KEY."
-
+For security reasons, we recommend storing your key in an environment variable rather than including it in your code. 
+The Conda documentation provides 
+`instructions for saving environment variables <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#saving-environment-variables>`__ 
+in conda environments for different operating systems. The example code on this page assumes that the 
+API key is stored in an environment variable called ``IPUMS_API_KEY``.
 
 A Simple Example
 ****************
@@ -80,7 +85,7 @@ For instance, we can request 2012 Puerto Rico Community Survey data for age and 
     
     # Create an extract definition
     extract = MicrodataExtract(
-        "usa",
+        collection="usa",
         description="Sample USA extract",
         samples=["us2012b"],
         variables=["AGE", "SEX"],
@@ -98,6 +103,7 @@ Submit the extract to the IPUMS servers. After waiting for the extract to finish
     # Submit the extract request
     ipums.submit_extract(extract)
     print(f"Extract submitted with id {extract.extract_id}")
+    #> Extract submitted with id 1
 
     # Wait for the extract to finish
     ipums.wait_for_extract(extract)
@@ -106,7 +112,7 @@ Submit the extract to the IPUMS servers. After waiting for the extract to finish
     DOWNLOAD_DIR = Path(<your_download_dir>)
     ipums.download_extract(extract, download_dir=DOWNLOAD_DIR)
 
-At this point you can load your data using ``ipumspy`` readers described :ref:`above<ipumspy readers>`:
+For microdata collections, you can load your data using ipumspy readers described :ref:`above<ipumspy readers>`:
 
 .. code:: python
 
@@ -116,6 +122,9 @@ At this point you can load your data using ``ipumspy`` readers described :ref:`a
 
     # Get the data
     ipums_df = readers.read_microdata(ddi, DOWNLOAD_DIR / ddi.file_description.filename)
+
+Aggregate data collection data can be loaded with other python libraries. See :ref:`reading-aggregate-data` for
+examples.
 
 For additional information about the IPUMS API as well as technical documentation, visit the 
 `IPUMS developer portal <https://developer.ipums.org/>`__.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,16 +11,16 @@ found at `ipums.org <https://ipums.org>`_.
 What is ipumspy?
 ----------------
 
-``ipumspy`` is a collection of python tools for working with data downloaded from `IPUMS <https://ipums.org>`_ and for accessing that 
+ipumspy is a collection of python tools for working with data downloaded from `IPUMS <https://ipums.org>`_ and for accessing that 
 data via the `IPUMS API <https://developer.ipums.org/>`_.
 
-``ipumspy`` can only be used to request data for IPUMS data collections supported by the IPUMS API. See the :ref:`collection support table` table 
+ipumspy can only be used to request data for IPUMS data collections supported by the IPUMS API. See the :ref:`collection support table` table 
 for a list of currently supported collections. Support for other IPUMS data collections will be added as they become available via API.
 
 For more information about the IPUMS API program, IPUMS account registration, and API keys, see 
 the `IPUMS developer portal <https://developer.ipums.org/docs/apiprogram/>`_.
 
-Even for collections not yet supported by the API, ``ipumspy`` can be used to read and analyze
+Even for collections not yet supported by the API, ipumspy can be used to read and analyze
 data downloaded from the IPUMS website.
 
 Releases
@@ -31,7 +31,7 @@ This library's :doc:`change-log` details changes and fixes made with each releas
 How to Cite
 -----------
 
-If you use ``ipumspy`` in the context of academic or industry research, please
+If you use ipumspy in the context of academic or industry research, please
 cite IPUMS. For any given extract, the appropriate citation may be found in the
 accompanying DDI at:
 
@@ -42,7 +42,7 @@ accompanying DDI at:
 License and Credits
 -------------------
 
-``ipumspy`` is licensed under the `Mozilla Public License Version 2.0 <https://github.com/ipums/ipumspy/blob/master/LICENSE>`_.
+ipumspy is licensed under the `Mozilla Public License Version 2.0 <https://github.com/ipums/ipumspy/blob/master/LICENSE>`_.
 
 
 Indices and tables

--- a/docs/source/ipums_api/index.rst
+++ b/docs/source/ipums_api/index.rst
@@ -5,7 +5,7 @@
 IPUMS API
 =========
 
-``ipumspy`` provides a framework for users to submit extract requests and download IPUMS data via the IPUMS API.
+ipumspy provides a framework for users to submit extract requests and download IPUMS data via the IPUMS API.
 
 API Assets
 ----------
@@ -93,7 +93,7 @@ available features for all collections currently supported by the API:
     While the IPUMS API does not yet provide comprehensive metadata for microdata collections, you can use
     :py:meth:`.get_all_sample_info` to retrieve a dictionary of available sample IDs.
 
-Note that ``ipumspy`` may not necessarily support all the functionality currently supported by
+Note that ipumspy may not necessarily support all the functionality currently supported by
 the IPUMS API. See the `API documentation <https://developer.ipums.org/>`__ for more information 
 about its latest features.
 
@@ -134,7 +134,7 @@ AGE, SEX, RACE, STATEFIP, and MARST variables from the 2018 and 2019 American Co
 .. code:: python
     
     extract = MicrodataExtract(
-        "usa",
+        collection="usa",
         description="Sample USA extract",
         samples=["us2018a", "us2019a"],
         variables=["AGE", "SEX", "RACE", "STATEFIP", "MARST"],
@@ -147,6 +147,8 @@ AGE, SEX, RACE, STATEFIP, and MARST variables from the 2018 and 2019 American Co
   :doc:`Microdata extracts<ipums_api_micro/index>` - Information on microdata extract parameters
 
   :doc:`Aggregate data extracts<ipums_api_aggregate/index>` - Information on aggregate data extract parameters
+
+.. _submit-extract:
 
 Submit an Extract Request
 -------------------------
@@ -257,7 +259,7 @@ re-create and re-submit the old extract.
 Sharing Extract Definitions
 ---------------------------
 
-``ipumspy`` also makes it easier to share IPUMS extracts with collaborators.
+ipumspy also makes it easier to share IPUMS extracts with collaborators.
 By saving your extract as a standalone file, you can send it to other researchers
 or reviewers, allowing them to generate an identical extract and download 
 the same data used in your analysis. 
@@ -268,7 +270,14 @@ submit the request. The request will be processed under their account, but the d
 extract will be identical.
 
 .. note::
-    Sharing IPUMS extract definitions using files will ensure that your collaborators are able to submit the same extract definition to the IPUMS extract system. However, IPUMS data are updated to fix errors as we become aware of them and preserving extract definitions in a file do not insulate against these types of changes to data. In other words, if the IPUMS data included in the extract definition change between submission of extracts based on this definition, the resulting downloaded files will not be identical. IPUMS collections keep a log of errata and other changes on their websites.
+    Sharing IPUMS extract definitions using files will ensure that your collaborators are able to submit the 
+    same extract definition to the IPUMS extract system. However, IPUMS data are updated to fix errors as we 
+    become aware of them and preserving extract definitions in a file do not insulate against these types of 
+    changes to data. 
+    
+    In other words, if the IPUMS data included in the extract definition change between 
+    submission of extracts based on this definition, the resulting downloaded files will not be identical. 
+    IPUMS collections keep a log of errata and other changes on their websites.
 
 
 Using JSON
@@ -280,7 +289,7 @@ Use the following to save your extract object in JSON format:
 
     save_extract_as_json(extract, filename="my_extract.json")
 
-If you send this file to a collaborator, they can load it into ``ipumspy`` and submit it
+If you send this file to a collaborator, they can load it into ipumspy and submit it
 themselves:
 
 .. code:: python
@@ -294,7 +303,8 @@ themselves:
     extract = define_extract_from_json("my_extract.json")
     ipums.submit_extract(extract)
 
-    
+.. _using-yaml:
+
 Using YAML
 **********
 
@@ -316,7 +326,7 @@ the extract we made above, we could save a file called ``ipums.yaml``
       - STATEFIP
       - MARST
 
-We can load the file into ``ipumspy`` by parsing the file into a dictionary
+We can load the file into ipumspy by parsing the file into a dictionary
 and then converting the dictionary to a
 :class:`MicrodataExtract<ipumspy.api.extract.MicrodataExtract>` object.
 
@@ -329,7 +339,7 @@ and then converting the dictionary to a
         extract = extract_from_dict(yaml.safe_load(infile))
 
 .. tip::
-    You can also use the ``ipumspy`` :doc:`CLI<../cli>` to easily submit extract requests for
+    You can also use the ipumspy :doc:`CLI<../cli>` to easily submit extract requests for
     definitions saved in YAML format.
     
 .. _extract-histories:
@@ -337,7 +347,7 @@ and then converting the dictionary to a
 Extract Histories
 -----------------
 
-``ipumspy`` offers two ways to peruse your extract history for a given IPUMS data collection.
+ipumspy offers two ways to peruse your extract history for a given IPUMS data collection.
 
 :meth:`.get_previous_extracts()` can be used to retrieve your most recent extracts for a 
 given collection. By default, it retrieves your previous 10 extracts, but you can adjust

--- a/docs/source/ipums_api/index.rst
+++ b/docs/source/ipums_api/index.rst
@@ -264,8 +264,17 @@ Sharing Extract Definitions
 
 ``ipumspy`` also makes it easier to share IPUMS extracts with collaborators.
 By saving your extract as a standalone file, you can send it to other researchers
-or reviewers, allowing them to generate an identical extract and download *exactly*
-the same data used in your analysis.
+or reviewers, allowing them to generate an identical extract and download 
+the same data used in your analysis. 
+
+Collaborators submitting your extract definition will need to be registered with the 
+data collection represented in the extract and have their own API key to succesfully 
+submit the request. The request will be processed under their account, but the data in the resulting 
+extract will be identical.
+
+.. note::
+    Sharing IPUMS extract definitions using files will ensure that your collaborators are able to submit the same extract definition to the IPUMS extract system. However, IPUMS data are updated to fix errors as we become aware of them and preserving extract definitions in a file do not insulate against these types of changes to data. In other words, if the IPUMS data included in the extract definition change between submission of extracts based on this definition, the resulting downloaded files will not be identical. IPUMS collections keep a log of errata and other changes on their websites.
+
 
 Using JSON
 **********
@@ -290,13 +299,6 @@ themselves:
     extract = define_extract_from_json("my_extract.json")
     ipums.submit_extract(extract)
 
-.. note::
-    Collaborators submitting your extract definition will need to be registered with the
-    data collection represented in the extract and have their own API key to succesfully
-    submit the request.
-
-    The request will be processed under their account, but the data in the resulting
-    extract will be identical.
     
 Using YAML
 **********

--- a/docs/source/ipums_api/index.rst
+++ b/docs/source/ipums_api/index.rst
@@ -144,14 +144,9 @@ AGE, SEX, RACE, STATEFIP, and MARST variables from the 2018 and 2019 American Co
   The available extract definition options vary across collections. See the collection-specific
   documentation for details about specifying more complex extracts for each type:
   
-  :doc:`Microdata extracts<ipums_api_micro/index>`
-    Information on microdata extract parameters, including :class:`Variable<ipumspy.api.extract.Variable>` and
-    :class:`TimeUseVariable<ipumspy.api.extract.TimeUseVariable>` objects
+  :doc:`Microdata extracts<ipums_api_micro/index>` - Information on microdata extract parameters
 
-  :doc:`Aggregate data extracts<ipums_api_aggregate/index>`
-    Information on aggregate data extract parameters, including
-    :class:`Dataset<ipumspy.api.extract.Dataset>` and 
-    :class:`TimeSeriesTable<ipumspy.api.extract.TimeSeriesTable>` objects
+  :doc:`Aggregate data extracts<ipums_api_aggregate/index>` - Information on aggregate data extract parameters
 
 Submit an Extract Request
 -------------------------

--- a/docs/source/ipums_api/ipums_api_aggregate/index.rst
+++ b/docs/source/ipums_api/ipums_api_aggregate/index.rst
@@ -149,8 +149,7 @@ are applied to all datasets in the extract. It is not possible to request differ
 datasets in a single extract.
 
 .. note::
-   Currently, NHGIS only supports extent selection for census blocks and block groups. However, extent selection
-   availability may be expanded to more geographic levels in the future.
+   Currently, NHGIS only supports extent selection for census blocks and block groups.
 
 Time Series Tables
 ------------------

--- a/docs/source/ipums_api/ipums_api_aggregate/index.rst
+++ b/docs/source/ipums_api/ipums_api_aggregate/index.rst
@@ -5,8 +5,7 @@
 Aggregate Data Extracts
 =======================
 
-In contrast to microdata collections, IPUMS aggregate data collections distribute
-aggregated statistics for a set of geographic units.
+IPUMS aggregate data collections distribute aggregated statistics for a set of geographic units.
 
 Currently, `IPUMS NHGIS <https://www.nhgis.org/>`__ is the only aggregate data collection
 supported by the IPUMS API.
@@ -30,10 +29,14 @@ For example:
 
 .. code:: python
 
+   from ipumspy import AggregateDataExtract, Dataset
+
    extract = AggregateDataExtract(
-      "nhgis",
+      collection="nhgis",
       description="An NHGIS extract example",
-      datasets=[Dataset("1990_STF1", ["NP1", "NP2"], ["county"])],
+      datasets=[
+         Dataset(name="1990_STF1", data_tables=["NP1", "NP2"], geog_levels=["county"])
+      ]
    )
 
 This instantiates an ``AggregateDataExtract`` object for the IPUMS NHGIS data collection
@@ -65,10 +68,10 @@ Use the :class:`Dataset <ipumspy.api.extract.Dataset>` class to specify these pa
 .. code:: python
 
    extract = AggregateDataExtract(
-      "nhgis",
+      collection="nhgis",
       description="An NHGIS example extract",
       datasets=[
-         Dataset("2000_SF1a", data_tables=["NP001A", "NP031A"], geog_levels=["state"])
+         Dataset(name="2000_SF1a", data_tables=["NP001A", "NP031A"], geog_levels=["state"])
       ],
    )
 
@@ -77,11 +80,11 @@ Some datasets span multiple years and require a selection of ``years``:
 .. code:: python
 
    extract = AggregateDataExtract(
-      "nhgis",
+      collection="nhgis",
       description="An NHGIS example extract",
       datasets=[
          Dataset(
-            "1988_1997_CBPa",
+            name="1988_1997_CBPa",
             data_tables=["NT004"],
             geog_levels=["county"],
             years=[1988, 1989, 1990],
@@ -98,11 +101,11 @@ for a dataset with the ``breakdown_values`` keyword argument:
 .. code:: python
 
    extract = AggregateDataExtract(
-      "nhgis",
+      collection="nhgis",
       description="An NHGIS example extract",
       datasets=[
          Dataset(
-               "2000_SF1a",
+               name="2000_SF1a",
                data_tables=["NP001A", "NP031A"],
                geog_levels=["state"],
                breakdown_values=["bs21.ge01", "bs21.ge43"],  # Urban + Rural breakdowns
@@ -132,11 +135,11 @@ a trailing 0):
 .. code:: python
 
    extract = AggregateDataExtract(
-      "nhgis",
+      collection="nhgis",
       description="Extent selection example",
       datasets=[
-         Dataset("2018_2022_ACS5a", ["B01001"], ["blck_grp"]),
-         Dataset("2017_2021_ACS5a", ["B01001"], ["blck_grp"])
+         Dataset(name="2018_2022_ACS5a", data_tables=["B01001"], geog_levels=["blck_grp"]),
+         Dataset(name="2017_2021_ACS5a", data_tables=["B01001"], geog_levels=["blck_grp"])
       ],
       geographic_extents=["010", "050"]
    )
@@ -165,8 +168,10 @@ level for the data:
 
 .. code:: python
 
+   from ipumspy import AggregateDataExtract, TimeSeriesTable
+
    extract = AggregateDataExtract(
-      "nhgis",
+      collection="nhgis",
       description="An NHGIS example extract: time series tables",
       time_series_tables=[TimeSeriesTable("CW3", geog_levels=["county", "state"])],
    )
@@ -177,7 +182,7 @@ You can select a subset of available years with the ``years`` argument:
 .. code:: python
    
    extract = AggregateDataExtract(
-      "nhgis",
+      collection="nhgis",
       description="An NHGIS example extract: time series tables",
       time_series_tables=[
          TimeSeriesTable("CW3", geog_levels=["county", "state"], years=[1990, 2000])
@@ -191,7 +196,7 @@ into separate files (by default, time is arranged across columns).
 .. code:: python
    
    extract = AggregateDataExtract(
-      "nhgis",
+      collection="nhgis",
       description="An NHGIS example extract: time series tables",
       time_series_tables=[
          TimeSeriesTable("CW3", geog_levels=["county", "state"], years=[1990, 2000])
@@ -211,7 +216,7 @@ simply by specifying their names:
 .. code:: python
 
    AggregateDataExtract(
-      "nhgis",
+      collection="nhgis",
       shapefiles=["us_county_2021_tl2021", "us_county_2020_tl2020"]
    )
 
@@ -226,11 +231,11 @@ datasets:
 
    # Total state-level population from 2000 and 2010 decennial census
    extract = AggregateDataExtract(
-      "nhgis",
+      collection="nhgis",
       description="An NHGIS example extract",
       datasets=[
-         Dataset("2000_SF1a", ["NP001A"], ["state"]),
-         Dataset("2010_SF1a", ["P1"], ["state"]))
+         Dataset(name="2000_SF1a", data_tables=["NP001A"], geog_levels=["state"]),
+         Dataset(name="2010_SF1a", data_tables=["P1"], geog_levels=["state"])
       ],
       shapefiles=["us_state_2000_tl2010", "us_state_2010_tl2010"]
    )
@@ -242,11 +247,11 @@ several ACS years at once using list comprehensions. For instance:
 .. code:: python
 
    acs1_names = ["2017_ACS1", "2018_ACS1", "2019_ACS1"]
-   acs1_specs = [Dataset(name, ["B01001"], ["state"]) for name in acs1_names]
+   acs1_specs = [Dataset(name, data_tables=["B01001"], geog_levels=["state"]) for name in acs1_names]
 
    # Total state-level population from 2017-2019 ACS 1-year estimates
    extract = AggregateDataExtract(
-      "nhgis",
+      collection="nhgis",
       description="An NHGIS example extract",
       datasets=acs1_specs,
    )

--- a/docs/source/ipums_api/ipums_api_aggregate/index.rst
+++ b/docs/source/ipums_api/ipums_api_aggregate/index.rst
@@ -18,7 +18,7 @@ Construct an extract for an IPUMS aggregate data collection using the
 An ``AggregateDataExtract`` must contain an IPUMS collection ID 
 and at least one data source. IPUMS NHGIS provides 3 different types of data sources:
 
-- Datasets + data tables
+- Datasets/data tables
 - Time series tables
 - Shapefiles
 
@@ -43,14 +43,16 @@ This instantiates an ``AggregateDataExtract`` object for the IPUMS NHGIS data co
 that includes a request for county-level data from tables NP1 (total population) and NP2 (total families) of 
 the 1990 STF 1 decennial census file.
 
-After instantiation, an ``AggregateDataExtract`` object can be submitted to the API for processing
-and downloaded as described on the :doc:`IPUMS API page<../../ipums_api/index>`.
+After instantiation, an ``AggregateDataExtract`` object can be
+:ref:`submitted to the API <submit-extract>` for processing.
 
 .. note::
    The IPUMS API provides a set of metadata endpoints for aggregate data collections that allow you
    to browse available data sources and identify their associated API codes.
 
-   ``ipumspy`` does not yet support these endpoints, but this support is planned for the near future.
+   You can also browse metadata interactively through the `NHGIS Data Finder <https://data2.nhgis.org/main>`_.
+
+   *TODO: cross-link to metadata docs when available*
 
 Datasets + Data Tables
 ----------------------
@@ -58,7 +60,8 @@ Datasets + Data Tables
 An IPUMS **dataset** contains a collection of **data tables** that each correspond to a particular tabulated summary statistic. 
 A dataset is distinguished by the years, geographic levels, and topics that it covers. For instance, 2021 1-year data from the 
 American Community Survey (ACS) is encapsulated in a single dataset. In other cases, a single census product will be split into 
-multiple datasets.
+multiple datasets, typically based on the lowest-level geography for which a set of tables is available. See the 
+`NHGIS documentation <https://www.nhgis.org/overview-nhgis-datasets>`_ for more details.
 
 To request data contained in an IPUMS dataset, you need to specify the name of the dataset, name of the data table(s) to request
 from that dataset, and the geographic level at which those tables should be aggregated.
@@ -149,12 +152,12 @@ are applied to all datasets in the extract. It is not possible to request differ
 datasets in a single extract.
 
 .. note::
-   Currently, NHGIS only supports extent selection for census blocks and block groups.
+   Currently, NHGIS only supports state-level extent selection for census blocks and block groups.
 
 Time Series Tables
 ------------------
 
-IPUMS NHGIS also provides **time series tables**, which are longitudinal data sources that link comparable statistics from multiple
+IPUMS NHGIS also provides `time series tables <https://www.nhgis.org/time-series-tables>`_—longitudinal data sources that link comparable statistics from multiple
 U.S. censuses in a single package. A table is comprised of one or more related time series, each 
 of which describes a single summary statistic measured at multiple times for a given geographic level.
 
@@ -239,14 +242,16 @@ datasets:
       shapefiles=["us_state_2000_tl2010", "us_state_2010_tl2010"]
    )
 
-In some cases, data table codes are consistent across datasets. This is the case for the American Community Survey
+In some cases, data table codes are consistent across datasets. This is often the case for the American Community Survey
 (ACS) datasets. This makes it easy to build an extract request for a specific data table for
 several ACS years at once using list comprehensions. For instance:
 
 .. code:: python
 
    acs1_names = ["2017_ACS1", "2018_ACS1", "2019_ACS1"]
-   acs1_specs = [Dataset(name, data_tables=["B01001"], geog_levels=["state"]) for name in acs1_names]
+   acs1_specs = [
+      Dataset(name, data_tables=["B01001"], geog_levels=["state"]) for name in acs1_names
+   ]
 
    # Total state-level population from 2017-2019 ACS 1-year estimates
    extract = AggregateDataExtract(
@@ -259,11 +264,11 @@ Data Format
 -----------
 
 By default, NHGIS extracts are provided in CSV format with only a single header row.
-However, you can request that your CSV data include a second, more descriptive header
-row by setting ``data_format="csv_header"``. 
+If you like, you can request that your CSV data include a second header row containing
+a description of each column's contents by setting ``data_format="csv_header"``.
 
 You can also request your data in
 fixed-width format if so desired. Note that unlike for microdata projects, NHGIS does
-not provide DDI codebook files (in XML format), which allow ``ipumspy`` to parse
+not provide DDI codebook files (in XML format), which allow ipumspy to parse
 microdata fixed-width files. Thus, loading an NHGIS fixed width file will require
 manual work to parse the file correctly.

--- a/docs/source/ipums_api/ipums_api_micro/index.rst
+++ b/docs/source/ipums_api/ipums_api_micro/index.rst
@@ -24,9 +24,9 @@ For example:
 .. code:: python
 
     extract = MicrodataExtract(
-        "usa",
-        ["us2012b"],
-        ["AGE", "SEX"],
+        collection="usa",
+        samples=["us2012b"],
+        variables=["AGE", "SEX"],
         description="An IPUMS extract example"
     )
 
@@ -54,9 +54,9 @@ instead:
 .. code:: python
 
     extract = MicrodataExtract(
-        "usa",
-        ["us2012b"],
-        ["AGE", "SEX"],
+        collection="usa",
+        samples=["us2012b"],
+        variables=["AGE", "SEX"],
         description="An IPUMS extract example",
         data_structure={"hierarchical": {}},
     )
@@ -71,9 +71,9 @@ an IPUMS MEPS extract on round records:
 .. code:: python
 
     extract = MicrodataExtract(
-        "meps",
-        ["mp2016"],
-        ["AGE", "SEX", "PREGNTRD"],
+        collection="meps",
+        samples=["mp2016"],
+        variables=["AGE", "SEX", "PREGNTRD"],
         description="An IPUMS extract example",
         data_structure={"rectangular": {"on": "R"}},
     )
@@ -119,9 +119,9 @@ by using the ``data_format`` argument:
 .. code:: python
 
     extract = MicrodataExtract(
-        "usa",
-        ["us2012b"],
-        ["AGE", "SEX"],
+        collection="usa",
+        samples=["us2012b"],
+        variables=["AGE", "SEX"],
         description="An IPUMS extract example",
         data_format="csv",
     )
@@ -138,9 +138,9 @@ demonstrates adding features to the following IPUMS CPS extract.
 .. code:: python
 
     extract = MicrodataExtract(
-        "cps",
-        ["cps2022_03s"],
-        ["AGE", "SEX", "RACE"],
+        collection="cps",
+        samples=["cps2022_03s"],
+        variables=["AGE", "SEX", "RACE"],
         description="A CPS extract example"
     )
 
@@ -195,9 +195,9 @@ example extract of the 2021 ACS data from IPUMS USA:
 .. code:: python
 
     extract = MicrodataExtract(
-        "usa",
-        ["us2021a"],
-        ["AGE", "SEX", "RACE"],
+        collection="usa",
+        samples=["us2021a"],
+        variables=["AGE", "SEX", "RACE"],
         description="Case selection example"
     )
 
@@ -233,9 +233,9 @@ who matches the case selection criteria. To do so, set the ``case_select_who`` f
 .. code:: python
 
     extract = MicrodataExtract(
-        "usa",
-        ["us2021a"],
-        ["AGE", "SEX", "RACE"],
+        collection="usa",
+        samples=["us2021a"],
+        variables=["AGE", "SEX", "RACE"],
         description="Case selection example",
         case_select_who = "households"
     )
@@ -257,9 +257,9 @@ data quality flags:
 .. code:: python
 
     extract = MicrodataExtract(
-        "cps",
-        ["cps2022_03s"],
-        ["AGE", "SEX", "RACE"],
+        collection="cps",
+        samples=["cps2022_03s"],
+        variables=["AGE", "SEX", "RACE"],
         data_quality_flags=True
     )
 
@@ -292,9 +292,9 @@ data quality flag for RACE (``data_quality_flags``).
 .. code:: python
 
     fancy_extract = MicrodataExtract(
-        "cps",
-        ["cps2022_03s"],
-        [
+        collection="cps",
+        samples=["cps2022_03s"],
+        variables=[
             Variable(name="AGE",
                      attached_characteristics=["spouse"]),
             Variable(name="SEX",

--- a/docs/source/ipums_api/ipums_api_micro/index.rst
+++ b/docs/source/ipums_api/ipums_api_micro/index.rst
@@ -33,19 +33,19 @@ For example:
 This instantiates a ``MicrodataExtract`` object for the `IPUMS USA <https://usa.ipums.org/usa/>`__ 
 data collection that includes the us2012b (2012 PRCS) sample, and the variables AGE and SEX.
 
-After instantiation, a ``MicrodataExtract`` object can be submitted to the API for processing
-and downloaded as described on the :doc:`IPUMS API page<../../ipums_api/index>`.
+After instantiation, a ``MicrodataExtract`` object can be
+:ref:`submitted to the API <submit-extract>` for processing.
 
 Data Structures
 ---------------
 
 IPUMS microdata extracts can be requested in rectangular, hierarhical, or household-only structures.
 
-- Rectangular data combine data for different record types into single records in the output. 
+- **Rectangular** data combine data for different record types into single records in the output. 
   For instance, rectangular-on-person data provide person-level records with all requested household
   information attached to the persons in that household.
-- Hierarchical data contain separate records for different record types.
-- Household-only data contain household records without any person records.
+- **Hierarchical** data contain separate records for different record types.
+- **Household-only** data contain household records without any person records.
 
 The ``data_structure`` argument defaults to ``{"rectangular": {"on": "P"}}``, which requests a 
 rectangular, person-level extract. The code snippet below requests a hierarchical USA extract 
@@ -170,7 +170,7 @@ Select Cases
 ~~~~~~~~~~~~
 
 IPUMS allows users to restrict the records included in their extract based on values of included 
-variables. In ``ipumspy``, use :meth:`.select_cases` to do so. This method takes a variable name and
+variables. In ipumspy, use :meth:`.select_cases` to do so. This method takes a variable name and
 a list of values for that variable. The resulting extract will only include the records whose data
 for that variable match the indicated values.
 
@@ -182,7 +182,7 @@ IPUMS CPS extract.
     extract.select_cases("SEX", ["2"])
 
 .. note::
-    The :meth:`.select_cases` can only be used with categorical variables, and the indictated
+    :meth:`.select_cases` can only be used with categorical variables, and the indictated
     variables must already be present in the IPUMS extract object.
 
 Detailed Codes
@@ -213,7 +213,7 @@ a general category, like "Two major races", can use general codes:
 However, to identify respondents belonging to more specific categories, you would need
 to use detailed codes instead. For instance, to identify respondents who identify as both
 White and Asian, you can use the detailed codes representing the intersection of White
-and each of the other Asian response options (e.g. Chinese, Japanese, etc.).
+and each of the other Asian response options (e.g., Chinese, Japanese, etc.).
 
 To do this, in addition to specifying the correct detailed codes, set the ``general`` 
 flag to ``False``:

--- a/docs/source/reading_data.rst
+++ b/docs/source/reading_data.rst
@@ -87,7 +87,7 @@ in the ``ipums_df`` data frame from above, using the ``"Female"`` label:
     # Filter to records where SEX is Female
     women = ipums_df[ipums_df["SEX"] == sex_info.codes["Female"]]
 
-It is =possible to filter both using labels as well as numeric values.
+It is possible to filter both using labels as well as numeric values.
 The following retains only women over the age of 16 in ``ipums_df``:
 
 .. code:: python
@@ -120,7 +120,9 @@ For instance, to list the names of the files contained in an extract:
 
     fname = "<path/to/zip/file>"
 
+    # a list of individual file names from inside the .zip file
     names = ZipFile(fname).namelist()
+    #> ['nhgis0025_csv/nhgis0025_ds120_1990_county_codebook.txt', 'nhgis0025_csv/nhgis0025_ds120_1990_county.csv']
 
 You can use the names of the containing files to identify the files you wish to load. Here, we use
 pandas to load the compressed csv file:
@@ -129,14 +131,15 @@ pandas to load the compressed csv file:
 
     # Read first data file in the extract
     with ZipFile(fname) as z:
-        with z.open(names[0]) as f:
+        with z.open(names[1]) as f:
             data = pd.read_csv(f)
 
 .. note::
-    IPUMS NHGIS does allow you to request an extract in fixed-width format, but ipumspy does not
-    provide methods to parse these files. If you want to load fixed-width NHGIS data, you will
-    need to parse these files yourself, possibly using the command files for other
-    software libraries that come in NHGIS fixed-width extracts.
+    IPUMS NHGIS does allow you to request an extract in fixed-width format, but ``ipumspy`` does not
+    provide methods to parse these files as it does for Microdata because IPUMS NHGIS does not provide
+    the necessary DDI codebook.
+
+Shapefile data is delivered in a nested zipfile that can also be unpacked using the ``ZipFile`` module and read using third party libraries such as geopandas.
 
 Reading Non-Extractable IPUMS Collections
 -----------------------------------------

--- a/docs/source/reading_data.rst
+++ b/docs/source/reading_data.rst
@@ -8,7 +8,7 @@ Reading IPUMS Data
 Reading IPUMS Microdata Extracts
 --------------------------------
 
-Reading IPUMS data into a Pandas data frame using ``ipumspy`` requires a fixed-width or csv IPUMS extract data file and an IPUMS xml DDI file.
+Reading IPUMS data into a pandas data frame using ipumspy requires a fixed-width or csv IPUMS extract data file and an IPUMS xml DDI file.
 
 To read a fixed-width rectangular IPUMS extract:
 
@@ -95,13 +95,15 @@ The following retains only women over the age of 16 in ``ipums_df``:
     adult_women = ipums_df[(ipums_df["SEX"] == sex_info.codes["Female"]) &
                            (ipums_df["AGE"] > 16)]
 
+.. _reading-aggregate-data:
+
 Reading IPUMS Aggregate Data Extracts
 -------------------------------------
 
 By default, extracts for aggregate data projects are provided in csv format, 
 and therefore don't include DDI metadata files found in microdata extracts. While aggregate data
-collections do provide codebook metadata files, they are in text format and are designed to be human
-readable rather used to parse the fixed-width files common for microdata projects.
+collections do provide codebook metadata files, they are in text format and are designed to be 
+human-readable rather used to parse the fixed-width files common for microdata projects.
 
 .. attention::
     Aggregate data codebook files contain the citation information for these collections; if you 
@@ -135,7 +137,7 @@ pandas to load the compressed csv file:
             data = pd.read_csv(f)
 
 .. note::
-    IPUMS NHGIS does allow you to request an extract in fixed-width format, but ``ipumspy`` does not
+    IPUMS NHGIS does allow you to request an extract in fixed-width format, but ipumspy does not
     provide methods to parse these files as it does for Microdata because IPUMS NHGIS does not provide
     the necessary DDI codebook.
 
@@ -145,8 +147,8 @@ Reading Non-Extractable IPUMS Collections
 -----------------------------------------
 
 The `IPUMS YRBSS <https://www.ipums.org/projects/ipums-yrbss>`__ and `IPUMS NYTS <https://www.ipums.org/projects/ipums-nyts>`__ data 
-collections are not accessed through the IPUMS extract system, but are available for download in their entirety. ``ipumspy`` has 
-functionality to download these datasets (:py:meth:`~noextract.download_noextract_data()`) and parse the yml format codebooks 
-that come packaged with the ``ipumspy`` library (:py:meth:`~noextract.read_noextract_codebook()`). This codebook object can 
-then be used to read the downloaded dataset into a Pandas data frame using :py:meth:`~readers.read_microdata()` as with other 
+collections are not accessed through the IPUMS extract system, but are available for download in their entirety. ipumspy has 
+functionality to download these datasets (:py:meth:`~noextract.download_noextract_data()`) and parse the YAML format codebooks 
+that come packaged with the ipumspy library (:py:meth:`~noextract.read_noextract_codebook()`). This codebook object can 
+then be used to read the downloaded dataset into a pandas data frame using :py:meth:`~readers.read_microdata()` as with other 
 IPUMS microdata extracts retrieved via the IPUMS extract system.

--- a/src/ipumspy/api/core.py
+++ b/src/ipumspy/api/core.py
@@ -87,8 +87,9 @@ class IpumsApiClient:
         Args:
             api_key: User's IPUMS API key
             base_url: IPUMS API url
+            api_version: IPUMS API version
             num_retries: number of times a request will be retried before
-                        raising `TransientIpumsApiException`
+                        raising ``TransientIpumsApiException``
             session: requests session object
 
         """
@@ -201,8 +202,7 @@ class IpumsApiClient:
                 then ``extract`` must be a ``BaseExtract``
 
         Returns:
-            str: The status of the request. Valid statuses are:
-                 'queued', 'started', 'completed', 'failed', or 'not found'
+            str: The status of the request. Valid statuses are: 'queued', 'started', 'completed', 'failed', or 'not found'
         """
         extract_id, collection = _extract_and_collection(extract, collection)
 
@@ -244,7 +244,7 @@ class IpumsApiClient:
                 extract data file.
             sas_command_file: Set to True to download the SAS command file with the
                 extract data file.
-            R_command_file: Set to True to download the R command file with the
+            r_command_file: Set to True to download the R command file with the
                 extract data file.
         """
         extract_id, collection = _extract_and_collection(extract, collection)
@@ -431,11 +431,12 @@ class IpumsApiClient:
         """
         Returns details about a past IPUMS extract
 
-        extract: The extract to download. This extract must have been submitted.
+        Args:
+            extract: The extract to download. This extract must have been submitted.
                 Alternatively, can be an extract id. If an extract id is provided, you
                 must supply the collection name
-        collection: The name of the collection to pull the extract from. If None,
-            then ``extract`` must be a ``BaseExtract``
+            collection: The name of the collection to pull the extract from. If None,
+                then ``extract`` must be a ``BaseExtract``
 
         Returns:
             An IPUMS extract definition
@@ -484,13 +485,14 @@ class IpumsApiClient:
         collection: Optional[str] = None,
     ) -> bool:
         """
-        Returns True if the IPUMS extract's files have been expired from the cache.
+        Returns ``True`` if the IPUMS extract's files have been expired from the cache.
 
-        extract: An extract object. This extract must have been submitted.
-                 Alternatively, can be an extract id. If an extract id is provided, you
-                 must supply the collection name
-        collection: The name of the collection to pull the extract from. If None,
-            then ``extract`` must be a ``BaseExtract``
+        Args:
+            extract: An extract object. This extract must have been submitted.
+                    Alternatively, can be an extract id. If an extract id is provided, you
+                    must supply the collection name.
+            collection: The name of the collection to pull the extract from. If None,
+                    then ``extract`` must be a ``BaseExtract``.
         """
         extract_id, collection = _extract_and_collection(extract, collection)
         extract_definition = self.get_extract_info(extract_id, collection)

--- a/src/ipumspy/ddi.py
+++ b/src/ipumspy/ddi.py
@@ -83,7 +83,7 @@ class VariableDescription:
     @property
     def pandas_type(self) -> type:
         """
-        The Pandas type of this variable. This supports the recently added nullable
+        The pandas type of this variable. This supports the recently added nullable
         pandas dtypes, and so the integer type is "Int64" and the string type is
         "string" (instead of "object")
         """


### PR DESCRIPTION
Some documentation tweaks.

A couple other things that I didn't touch but I think could use some tweaking:

- [x] As someone who is not super familiar with the NHGIS data, a little explanation of Census Products that are split into multiple datasets (in general, which ones and why?) might be helpful 
- [x] Some description of what is in the "more descriptive header row" would be helpful too
- [x] I noticed the note about NHGIS metadata access via API - based on my understanding, that will be rolled into this release and that note can go away?
- [x] In that vein though, it might be helpful to include some links where users can browse the metadata via the web.
