### PR TITLE
updated metadata dataclasses

### DIFF
--- a/src/ipumspy/api/core.py
+++ b/src/ipumspy/api/core.py
@@ -617,7 +617,5 @@ class IpumsApiClient:
         ).json()
 
         metadata_resp = {_camel_to_snake(k): v for (k, v) in metadata_resp.items()}
-        metadata_class = IpumsMetadata._metadata_classes[obj.metadata_type]
-        metadata = metadata_class(collection=obj.collection, **metadata_resp)
-
-        return metadata
+        obj.populate(metadata_resp)
+        return obj

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -62,3 +62,9 @@ def test_get_metadata(live_api_client: IpumsApiClient):
 
     assert len(ds.data_tables) == 100
     assert len(dt.variables) == 49
+    
+
+def test_collection_validity():
+    with pytest.raises(ValueError) as exc_info:
+        ds = DatasetMetadata("usa", "1990_STF1")
+    assert exc_info.value.args[0] == "DatasetMetadata is not a valid metadata type for the usa collection."


### PR DESCRIPTION
I think this is the direction to go in for the metadata objects rather than what is currently on the dev-0.6.0 branch. I have modified things to make more efficient use of the features offered by `dataclass` to reduce duplication across metadata classes and to slightly simplify the `get_metadata()` method. The other thing I like about this approach is it makes it a little more clear from the code that some attributes need to be requested, even if that method will not be called directly in most workflows.