### PR TITLE
add geographic_instances to time series

### DIFF
--- a/src/ipumspy/api/metadata.py
+++ b/src/ipumspy/api/metadata.py
@@ -129,7 +129,10 @@ class TimeSeriesTableMetadata(IpumsMetadata):
     """Dictionary containing information on the available data years for the time series table"""
     geog_levels: Optional[List[Dict]] = field(default=None, init=False)
     """Dictionary containing names and descriptions for the geographic levels available for the time series table"""
+    geographic_instances: Optional[List[Dict]] = field(default=None, init=False)
+    """Dictionary containing names and descriptions for all valid geographic extents for the dataset"""
 
+    
     def __post_init__(self):
         self._path = f"metadata/time_series_tables/{self.name}"
         self._validate_collection()


### PR DESCRIPTION
Without this patch I was getting the error "KeyError: "TimeSeriesTableMetadata has no attribute 'geographic_instances'." when doing the following call: 

ipums = IpumsApiClient(IPUMS_API_KEY)

timeseries_metadata = ipums.get_metadata(TimeSeriesTableMetadata(collection="nhgis", name="CW3"))

I have never attempted to contribute to an open source project before so I'm sorry if there is some protocols or documentation here I am missing! 