### PR TITLE
Documentation tweaks for TST extent selection updates

### DIFF
--- a/docs/source/change-log.rst
+++ b/docs/source/change-log.rst
@@ -14,7 +14,7 @@ This project adheres to `Semantic Versioning`_.
 -----
 
 * The IPUMS API now supports geographic extent selection for NHGIS time series tables.
-  Accordingly, a `geographic_instances` attribute has been added to the 
+  Accordingly, a ``geographic_instances`` attribute has been added to the 
   :py:class:`~ipumspy.api.metadata.TimeSeriesTableMetadata` class to store retrieved
   geographic extent metadata for a given time series table.
 

--- a/docs/source/ipums_api/ipums_api_aggregate/index.rst
+++ b/docs/source/ipums_api/ipums_api_aggregate/index.rst
@@ -232,7 +232,8 @@ a trailing 0):
 .. tip::
    You can see available extent selection API codes, if any, in the ``geographic_instances`` attribute of
    a submitted :class:`DatasetMetadata <ipumspy.api.metadata.DatasetMetadata>` or 
-   :class:`TimeSeriesTableMetadata <ipumspy.api.metadata.TimeSeriesTableMetadata>` object.
+   :class:`TimeSeriesTableMetadata <ipumspy.api.metadata.TimeSeriesTableMetadata>` object. The 
+   ``geog_levels`` attribute indicates whether a given geographic level supports extent selection.
 
 Note that the selected extents are applied to all datasets and time series tables in an extract. 
 It is not possible to request different extents for different data sources in a single extract.

--- a/src/ipumspy/api/extract.py
+++ b/src/ipumspy/api/extract.py
@@ -713,8 +713,7 @@ class AggregateDataExtract(BaseExtract, collection_type="aggregate_data"):
             description: short description of your extract
             data_format: desired format of the extract data file. One of ``"csv_no_header"``, ``"csv_header"``, or ``"fixed_width"``.
             geographic_extents: Geographic extents to use for all ``datasets`` and ``time_series_tables`` in the extract definition (for instance, to
-                                to obtain data within a particular state). Note that geographic extent selection is only supported for geographies
-                                that nest within states.
+                                to obtain data within a particular state).
             tst_layout: desired data layout for all  ``time_series_tables`` in the extract definition.
                         One of ``"time_by_column_layout"`` (default), ``"time_by_row_layout"``, or ``"time_by_file_layout"``.
             breakdown_and_data_type_layout: desired layout of any ``datasets`` that have multiple data types or breakdown values. Either


### PR DESCRIPTION
The IPUMS API response for the time series table metadata endpoint was just updated to include an additional field that indicates whether a particular geog level for a time series table supports geographic extent selection. Instead of explicitly mentioning that extent selection is supported up to state level, this tweaks the documentation to indicate that the metadata itself can be used to identify whether a geog level supports extent selection.

A fairly trivial change, but thought it worth clarifying before release, and makes the docs more robust if extent selection is updated further in the future.