### PR TITLE
Clarify metadata documentation

### DIFF
--- a/docs/source/ipums_api/index.rst
+++ b/docs/source/ipums_api/index.rst
@@ -149,10 +149,9 @@ IPUMS Metadata
 Microdata Collections
 *********************
 
-.. note::
-  Currently, comprehensive IPUMS API metadata is only available for IPUMS NHGIS.
-  For microdata collections, only sample information is available. You can also obtain a dictionary 
-  of sample codes with :py:meth:`.get_all_sample_info`.
+Currently, comprehensive IPUMS API metadata is only available for IPUMS NHGIS.
+For microdata collections, only sample information is available. You can obtain a dictionary 
+of sample codes with :py:meth:`.get_all_sample_info`.
 
 Aggregate Data Collections
 **************************

--- a/docs/source/ipums_api/ipums_api_aggregate/index.rst
+++ b/docs/source/ipums_api/ipums_api_aggregate/index.rst
@@ -125,6 +125,9 @@ single file using the ``breakdown_and_data_type_layout`` argument.
 Dataset + Data Table Metadata
 +++++++++++++++++++++++++++++
 
+You can obtain a listing of datasets and data tables as well as detailed information about individual
+datasets and data tables via the :ref:`IPUMS Metadata API <ipums-metadata>`.
+
 Use the :class:`DatasetMetadata <ipumspy.api.metadata.DatasetMetadata>` data class to browse the available
 specification options for a particular dataset and identify the codes to use when
 requesting data from the API:
@@ -203,8 +206,12 @@ into separate files (by default, time is arranged across columns).
       tst_layout="time_by_row_layout",
    )
 
-As with datasets and data tables, you can request metadata about the available specification options
-for a specific time series table using the :class:`TimeSeriesTableMetadata <ipumspy.api.metadata.TimeSeriesTableMetadata>` class.
+Time Series Table Metadata
+++++++++++++++++++++++++++
+
+As with datasets and data tables, you can request :ref:`metadata <ipums-metadata>` about the available specification options
+for a specific time series table using the :class:`TimeSeriesTableMetadata <ipumspy.api.metadata.TimeSeriesTableMetadata>` class
+with :py:meth:`.get_metadata`.
 
 Geographic Extent Selection
 ---------------------------
@@ -253,6 +260,13 @@ simply by specifying their names:
       collection="nhgis",
       shapefiles=["us_county_2021_tl2021", "us_county_2020_tl2020"]
    )
+
+Shapefile Metadata
+++++++++++++++++++
+
+You can access a listing of shapefile API codes and descriptions via the :ref:`IPUMS Metadata API <ipums-metadata>` 
+using :py:meth:`.get_metadata_catalog` with ``metadata_type="shapefiles"``. The IPUMS API does not provide 
+detailed metadata for individual shapefiles.
 
 Multiple Data Sources
 ---------------------


### PR DESCRIPTION
Indicates that shapefile metadata is available via the IPUMS metadata API and improves cross linking between the metadata section of the main IPUMS API help page and the Aggregate Data Extracts page.