### PR TITLE
Attach characteristics and ddi reader bug fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ipumspy"
-version = "0.8.0"
+version = "0.8.1"
 description = "A collection of tools for working with IPUMS data"
 authors = ["Kevin H. Wilson <kevin_wilson@brown.edu>",
            "Renae Rodgers <rodge103@umn.edu>"]

--- a/src/ipumspy/api/extract.py
+++ b/src/ipumspy/api/extract.py
@@ -681,7 +681,7 @@ class MicrodataExtract(BaseExtract, collection_type="microdata"):
             }
 
         # XXX shoehorn fix until server-side bug is fixed
-        if self.collection == "meps" or self.collection == "dhs":
+        if self.collection in ["meps", "dhs", "mtus", "ahtus"]:
             for variable in built["variables"].keys():
                 built["variables"][variable].pop("attachedCharacteristics")
 

--- a/src/ipumspy/ddi.py
+++ b/src/ipumspy/ddi.py
@@ -243,21 +243,21 @@ class FileDescription:
             rectype_keyvar = elt.find("./ddi:fileStrc/ddi:recGrp", namespaces).attrib[
                 "keyvar"
             ]
-        # (new ddi ordering of rectypes): if we get a key error, the first appearance now is 
-        # the top level record type, which does not have the keyvar attribute - 
+        # (new ddi ordering of rectypes): if we get a key error, the first appearance now is
+        # the top level record type, which does not have the keyvar attribute -
         # so now grabbing from the last record type in the hierarchy
         except KeyError:
-            rectype_idvar = elt.findall("./ddi:fileStrc/ddi:recGrp", namespaces)[-1].attrib[
-                "recidvar"
-            ]
-            rectype_keyvar = elt.findall("./ddi:fileStrc/ddi:recGrp", namespaces)[-1].attrib[
-                "keyvar"
-            ]
+            rectype_idvar = elt.findall("./ddi:fileStrc/ddi:recGrp", namespaces)[
+                -1
+            ].attrib["recidvar"]
+            rectype_keyvar = elt.findall("./ddi:fileStrc/ddi:recGrp", namespaces)[
+                -1
+            ].attrib["keyvar"]
         # if we get an Attribute Error, this is a rectangular file
         except AttributeError:
             rectype_idvar = ""
             rectype_keyvar = ""
-        
+
         return cls(
             filename=elt.find("./ddi:fileName", namespaces).text,
             description=elt.find("./ddi:fileCont", namespaces).text,

--- a/src/ipumspy/ddi.py
+++ b/src/ipumspy/ddi.py
@@ -231,9 +231,11 @@ class FileDescription:
             rts = [rectype.attrib["rectype"] for rectype in file_rectypes]
         except KeyError:
             rts = []
-        # rectype get rectype id var and rectype key var
+        # (old ddi ordering of record types): rectype get rectype id var and rectype key var
         # these should be the same across record types for all collections
-        # so we should be fine to just grab the first appearance of recidvar and keyvar
+        # so we should be fine to just grab the last appearance of recidvar and keyvar
+        # (the first appearance now is the top level record type, which does not have
+        # the keyvar attribute - so now grabbing from the last record type in the hierarchy)
         try:
             rectype_idvar = elt.find("./ddi:fileStrc/ddi:recGrp", namespaces).attrib[
                 "recidvar"
@@ -241,9 +243,21 @@ class FileDescription:
             rectype_keyvar = elt.find("./ddi:fileStrc/ddi:recGrp", namespaces).attrib[
                 "keyvar"
             ]
+        # (new ddi ordering of rectypes): if we get a key error, the first appearance now is 
+        # the top level record type, which does not have the keyvar attribute - 
+        # so now grabbing from the last record type in the hierarchy
+        except KeyError:
+            rectype_idvar = elt.findall("./ddi:fileStrc/ddi:recGrp", namespaces)[-1].attrib[
+                "recidvar"
+            ]
+            rectype_keyvar = elt.findall("./ddi:fileStrc/ddi:recGrp", namespaces)[-1].attrib[
+                "keyvar"
+            ]
+        # if we get an Attribute Error, this is a rectangular file
         except AttributeError:
             rectype_idvar = ""
             rectype_keyvar = ""
+        
         return cls(
             filename=elt.find("./ddi:fileName", namespaces).text,
             description=elt.find("./ddi:fileCont", namespaces).text,

--- a/tests/fixtures/atus_00040.xml
+++ b/tests/fixtures/atus_00040.xml
@@ -1,0 +1,3080 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="ipums-ddi-xslt.xsl"?>
+<codeBook ID="ddi2-27363a39-8e14-11e5-8c97-b82a72e0b782-atus_00040.dat-www.atusdata.org" version="2.5" xmlns="ddi:codebook:2_5" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="ddi:codebook:2_5 http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd">
+  <docDscr>
+    <citation>
+      <titlStmt>
+        <titl>Codebook for an ATUS Data Extract</titl>
+        <subTitl>DDI 2.5 metadata describing the extract file  'atus_00040.dat'</subTitl>
+        <IDNo>ddi2-27363a39-8e14-11e5-8c97-b82a72e0b782-atus_00040.dat-www.atusdata.org</IDNo>
+      </titlStmt>
+      <rspStmt>
+        <AuthEnty affiliation="University of Minnesota">IPUMS</AuthEnty>
+      </rspStmt>
+      <prodStmt>
+        <producer abbr="IPUMS" affiliation="University of Minnesota" role="Documentation">IPUMS</producer>
+        <prodDate date="2026-04-23">April 23, 2026</prodDate>
+        <prodPlac>IPUMS, 50 Willey Hall, 225 - 19th Avenue South, Minneapolis, MN 55455</prodPlac>
+      </prodStmt>
+      <distStmt>
+        <contact URI="https://ipums.org" affiliation="University of Minnesota">IPUMS</contact>
+      </distStmt>
+    </citation>
+  </docDscr>
+  <stdyDscr>
+    <citation>
+      <titlStmt>
+        <titl>User Extract atus_00040.dat</titl>
+      </titlStmt>
+      <rspStmt>
+        <AuthEnty affiliation="University of Minnesota">IPUMS</AuthEnty>
+      </rspStmt>
+      <prodStmt>
+        <producer abbr="IPUMS" affiliation="University of Minnesota" role="Documentation">IPUMS</producer>
+        <prodDate date="2026-04-23">April 23, 2026</prodDate>
+        <prodPlac>IPUMS, 50 Willey Hall, 225 - 19th Avenue South, Minneapolis, MN 55455</prodPlac>
+      </prodStmt>
+      <distStmt>
+        <contact URI="https://ipums.org" affiliation="University of Minnesota">IPUMS</contact>
+      </distStmt>
+      <serStmt>
+        <serName abbr="atus">IPUMS ATUS</serName>
+        <serInfo>DOI:10.18128/D060.V3.3</serInfo>
+      </serStmt>
+      <verStmt>
+        <version date="2026-04-23"/>
+      </verStmt>
+    </citation>
+    <stdyInfo>
+      <subject>
+        <topcClas vocab="IPUMS">Technical Household Variables -- HOUSEHOLD</topcClas>
+        <topcClas vocab="IPUMS">Technical Person Variables -- PERSON</topcClas>
+        <topcClas vocab="IPUMS">Weights Variables -- PERSON</topcClas>
+        <topcClas vocab="IPUMS">Core Demographic Variables -- PERSON</topcClas>
+        <topcClas vocab="IPUMS">Technical Activity Variables -- ACTIVITY</topcClas>
+        <topcClas vocab="IPUMS">Technical Who Variables -- WHO</topcClas>
+      </subject>
+      <sumDscr ID="sdatref-46">
+        <timePrd date="2024" event="single">2024</timePrd>
+        <nation abbr="us">United States</nation>
+      </sumDscr>
+      <notes><![CDATA[Additional notes on a sample that is part of this study:  ATUS 2024
+]]></notes>
+    </stdyInfo>
+    <dataAccs>
+      <useStmt>
+        <confDec required="no"><![CDATA[None]]></confDec>
+        <contact URI="http://atusdata.org/" affiliation="IPUMS">ATUS</contact>
+        <citReq><![CDATA[Publications and research reports based on the ATUS database must cite it appropriately. The citation should include the following:
+
+Sarah M. Flood, Liana C. Sayer, and Daniel Backman. American Time Use Survey Data Extract Builder: Version 3.3 [dataset]. College Park, MD: University of Maryland and Minneapolis, MN: IPUMS, 2025. https://doi.org/10.18128/D060.V3.3
+
+The licensing agreement for use of ATUS data requires that users supply us with the title and full citation for any publications, research reports, or educational materials making use of the data or documentation. Please add your citation to the IPUMS bibliography: http://bibliography.ipums.org/]]></citReq>
+        <conditions><![CDATA[Users of ATUS data must agree to abide by the conditions of use. A user's license is valid for one year and may be renewed.  Users must agree to the following conditions:
+
+(1) No fees may be charged for use or distribution of the data.  All persons are granted a limited license to use these data, but you may not charge a fee for the data if you distribute it to others.
+
+(2) Cite IPUMS appropriately.  For information on proper citation, refer to the citation requirement section of this DDI document.
+
+(3) Tell us about any work you do using the IPUMS.  Publications, research reports, or presentations making use of ATUS should be added to our Bibliography. Continued funding for the IPUMS depends on our ability to show our sponsor agencies that researchers are using the data for productive purposes.
+
+(4) Use it for GOOD -- never for EVIL.]]></conditions>
+        <disclaimer>The user of the data acknowledges that the original collector of the data, the authorized distributor of the data, and the relevant funding agency bear no responsibility for use of the data or for interpretations or inferences based upon such uses.</disclaimer>
+      </useStmt>
+    </dataAccs>
+    <notes><![CDATA[User-provided description:  test api call to live]]></notes>
+  </stdyDscr>
+  <fileDscr ID="ExtractData">
+    <fileTxt>
+      <fileName>atus_00040.dat</fileName>
+      <fileCont>Microdata records</fileCont>
+      <fileStrc type="hierarchical">
+        <recGrp recidvar="RECTYPE" rectype="1">
+          <labl>Household Record</labl>
+        </recGrp>
+        <recGrp keyvar="CASEID" recidvar="RECTYPE" rectype="2">
+          <labl>Person Record</labl>
+        </recGrp>
+        <recGrp keyvar="CASEID" recidvar="RECTYPE" rectype="3">
+          <labl>Activity Record</labl>
+        </recGrp>
+        <recGrp keyvar="CASEID" recidvar="RECTYPE" rectype="4">
+          <labl>Who Record</labl>
+        </recGrp>
+      </fileStrc>
+      <fileType charset="ISO-8859-1">ISO-8859-1 data file</fileType>
+      <format>fixed length fields</format>
+      <filePlac>IPUMS, 50 Willey Hall, 225 - 19th Avenue South, Minneapolis, MN 55455</filePlac>
+    </fileTxt>
+  </fileDscr>
+  <dataDscr><var ID="RECTYPE" dcml="0" files="ExtractData" intrvl="contin" name="RECTYPE" rectype="1 2 3 4">
+  <location EndPos="1" StartPos="1" width="1"/>
+  <labl>Record Type</labl>
+  <txt><![CDATA[RECTYPE assigns all household records the value "1"; person records are assigned "2"; activity records are assigned "3"; who records are assigned "4"; and eldercare records are assigned "5". This allows users to discriminate between different types of records in the data. Each household record is followed by one or more person records. ATUS respondents (LINENO=1) are followed by many activity records, which comprise the main time diary component of the data. Respondents may report many people with whom the activity was done; accordingly these records follow the activities to which they correspond. Finally, in 2011 forward, eldercare records include information about the individuals to whom the ATUS respondent has provided care.]]></txt>
+  <concept vocab="IPUMS">Technical Household Variables -- HOUSEHOLD</concept>
+  <varFormat schema="other" type="character"/>
+</var>
+<var ID="YEAR" dcml="0" files="ExtractData" intrvl="contin" name="YEAR" rectype="1 2 3 4">
+  <location EndPos="6" StartPos="2" width="5"/>
+  <labl>Survey year</labl>
+  <txt><![CDATA[YEAR reports the survey year.
+
+There are several other variables that report date information on the diary day.  See DATE for the date of the diary day, DAY for the day of the diary day, and MONTH for the month of the diary day.
+
+The ATUS interview took place 2-5 months after the final CPS interview.  Date information is also available for the final CPS interview.  See MONTH_CPS8 for the month of the final CPS interview and YEAR_CPS8 for the year of the final CPS interview.]]></txt>
+  <codInstr><![CDATA[YEAR is a four-digit numeric variable reporting the survey year.]]></codInstr>
+  <concept vocab="IPUMS">Technical Household Variables -- HOUSEHOLD</concept>
+  <varFormat schema="other" type="numeric"/>
+</var>
+<var ID="CASEID" dcml="0" files="ExtractData" intrvl="contin" name="CASEID" rectype="1 2 3 4">
+  <location EndPos="20" StartPos="7" width="14"/>
+  <labl>ATUS Case ID</labl>
+  <txt><![CDATA[CASEID is an identifying number unique to each household. 
+
+CASEID is the same as TUCASEID which is on the public use ATUS files. For user convenience CASEID has been converted to a numeric variable. Users who are trying to match ATUS-X files with public use ATUS files must be sure that CASEID and TUCASEID are of the same type.]]></txt>
+  <codInstr><![CDATA[CodesCASEID is a 14-digit numeric variable uniquely identifying each household.]]></codInstr>
+  <concept vocab="IPUMS">Technical Household Variables -- HOUSEHOLD</concept>
+  <varFormat schema="other" type="numeric"/>
+</var>
+<var ID="SERIAL" dcml="0" files="ExtractData" intrvl="contin" name="SERIAL" rectype="1 2 3 4">
+  <location EndPos="27" StartPos="21" width="7"/>
+  <labl>Household serial number</labl>
+  <txt><![CDATA[SERIAL is an identifying number unique to each respondent.]]></txt>
+  <codInstr><![CDATA[CodesSERIAL is a 7-digit numeric variable.]]></codInstr>
+  <concept vocab="IPUMS">Technical Household Variables -- HOUSEHOLD</concept>
+  <varFormat schema="other" type="numeric"/>
+</var>
+<var ID="PERNUM" dcml="0" files="ExtractData" intrvl="discrete" name="PERNUM" rectype="2">
+  <location EndPos="29" StartPos="28" width="2"/>
+  <labl>Person number (general)</labl>
+  <txt><![CDATA[PERNUM is constructed to uniquely identify each person within a given household. It is available for all household members whether they were present in the household at the time of the ATUS, CPS, or both. This is the only line number variable available for each person in every household. 
+
+LINENO was assigned to all household members present at the time of the ATUS interview. LINENO_CPS8 was assigned to all household members present at the time of the final CPS interview, 2-5 months before the ATUS interview. Because household composition could change, PERNUM, LINENO, and LINENO_CPS8 may not match.]]></txt>
+  <catgry>
+    <catValu>01</catValu>
+    <labl>1</labl>
+  </catgry>
+  <catgry>
+    <catValu>02</catValu>
+    <labl>2</labl>
+  </catgry>
+  <catgry>
+    <catValu>03</catValu>
+    <labl>3</labl>
+  </catgry>
+  <catgry>
+    <catValu>04</catValu>
+    <labl>4</labl>
+  </catgry>
+  <catgry>
+    <catValu>05</catValu>
+    <labl>5</labl>
+  </catgry>
+  <catgry>
+    <catValu>06</catValu>
+    <labl>6</labl>
+  </catgry>
+  <catgry>
+    <catValu>07</catValu>
+    <labl>7</labl>
+  </catgry>
+  <catgry>
+    <catValu>08</catValu>
+    <labl>8</labl>
+  </catgry>
+  <catgry>
+    <catValu>09</catValu>
+    <labl>9</labl>
+  </catgry>
+  <catgry>
+    <catValu>10</catValu>
+    <labl>10</labl>
+  </catgry>
+  <catgry>
+    <catValu>11</catValu>
+    <labl>11</labl>
+  </catgry>
+  <catgry>
+    <catValu>12</catValu>
+    <labl>12</labl>
+  </catgry>
+  <catgry>
+    <catValu>13</catValu>
+    <labl>13</labl>
+  </catgry>
+  <catgry>
+    <catValu>14</catValu>
+    <labl>14</labl>
+  </catgry>
+  <catgry>
+    <catValu>15</catValu>
+    <labl>15</labl>
+  </catgry>
+  <catgry>
+    <catValu>16</catValu>
+    <labl>16</labl>
+  </catgry>
+  <concept vocab="IPUMS">Technical Person Variables -- PERSON</concept>
+  <varFormat schema="other" type="numeric"/>
+</var>
+<var ID="LINENO" dcml="0" files="ExtractData" intrvl="discrete" name="LINENO" rectype="2">
+  <location EndPos="32" StartPos="30" width="3"/>
+  <labl>Person line number</labl>
+  <txt><![CDATA[LINENO identifies each person within a given ATUS respondent household.  It is only available for individuals who were in an ATUS respondent household at the time of the ATUS interview. ATUS respondents always have a LINENO value of 1. 
+
+LINENO_CPS8 is a person identifier that was assigned at the time of the final CPS interview, 2-5 months before the ATUS interview.  Because household composition may have changed between the dates of the CPS and ATUS interviews, LINENO and LINENO_CPS8 may not match. 
+
+PERNUM is an additional person identifier that is available for all person records in the dataset.]]></txt>
+  <catgry>
+    <catValu>001</catValu>
+    <labl>1</labl>
+  </catgry>
+  <catgry>
+    <catValu>002</catValu>
+    <labl>2</labl>
+  </catgry>
+  <catgry>
+    <catValu>003</catValu>
+    <labl>3</labl>
+  </catgry>
+  <catgry>
+    <catValu>004</catValu>
+    <labl>4</labl>
+  </catgry>
+  <catgry>
+    <catValu>005</catValu>
+    <labl>5</labl>
+  </catgry>
+  <catgry>
+    <catValu>006</catValu>
+    <labl>6</labl>
+  </catgry>
+  <catgry>
+    <catValu>007</catValu>
+    <labl>7</labl>
+  </catgry>
+  <catgry>
+    <catValu>008</catValu>
+    <labl>8</labl>
+  </catgry>
+  <catgry>
+    <catValu>009</catValu>
+    <labl>9</labl>
+  </catgry>
+  <catgry>
+    <catValu>010</catValu>
+    <labl>10</labl>
+  </catgry>
+  <catgry>
+    <catValu>011</catValu>
+    <labl>11</labl>
+  </catgry>
+  <catgry>
+    <catValu>012</catValu>
+    <labl>12</labl>
+  </catgry>
+  <catgry>
+    <catValu>013</catValu>
+    <labl>13</labl>
+  </catgry>
+  <catgry>
+    <catValu>014</catValu>
+    <labl>14</labl>
+  </catgry>
+  <catgry>
+    <catValu>015</catValu>
+    <labl>15</labl>
+  </catgry>
+  <catgry>
+    <catValu>016</catValu>
+    <labl>16</labl>
+  </catgry>
+  <catgry>
+    <catValu>017</catValu>
+    <labl>17</labl>
+  </catgry>
+  <catgry>
+    <catValu>018</catValu>
+    <labl>18</labl>
+  </catgry>
+  <catgry>
+    <catValu>019</catValu>
+    <labl>19</labl>
+  </catgry>
+  <catgry>
+    <catValu>999</catValu>
+    <labl>NIU (Not in universe)</labl>
+  </catgry>
+  <concept vocab="IPUMS">Technical Person Variables -- PERSON</concept>
+  <varFormat schema="other" type="numeric"/>
+</var>
+<var ID="WT06" dcml="0" files="ExtractData" intrvl="contin" name="WT06" rectype="2">
+  <location EndPos="49" StartPos="33" width="17"/>
+  <labl>Person weight, 2006 methodology</labl>
+  <txt><![CDATA[WT06 provides ATUS respondent weights based on the weighting methodology introduced in 2006. WT06 is available for all years and is the preferred weighting variable to use for most analyses.  It is the only weighting variable that is suitable for use in analyses that combine time use data from 2006 and later with data for earlier years.  The methodology used to construct WT06 ensures that the sums of the respondent weights add up to the appropriate number of weekday person-days and weekend person-days over the quarter, both for the population as a whole and for selected subpopulations. 
+
+All ATUS weights are probability weights. Users should take care to specify them properly in their statistical packages.
+
+Because the ATUS sample is not a simple random sample, standard errors calculated using the default options in most statistical packages will not be correct.  Calculation of correct standard errors requires the use of replicate weights.  RWT06 may be used in conjunction with WT06 for this purpose; for further details, see the description of RWT06.]]></txt>
+  <codInstr><![CDATA[CodesWT06 is a 16-digit numeric variable reporting the ATUS respondent probability weights. This variable can be used in all years.]]></codInstr>
+  <concept vocab="IPUMS">Weights Variables -- PERSON</concept>
+  <varFormat schema="other" type="numeric"/>
+</var>
+<var ID="AGE" dcml="0" files="ExtractData" intrvl="contin" name="AGE" rectype="2">
+  <location EndPos="52" StartPos="50" width="3"/>
+  <labl>Age</labl>
+  <txt><![CDATA[AGE reports the person's age in years as of his/her last birthday.
+
+AGE was collected during the ATUS interview, 2-5 months after the final CPS interview.  Age is also available for the final CPS interview (see AGE_CPS8).
+
+AGE is available for respondents who are aged 15 or over.]]></txt>
+  <codInstr><![CDATA[CodesAge is a 3 digit numeric variable reporting the person's age in years. This variable ranges from 0 to 85 except for 81 - 84 (see top codes).  
+
+996 = Refused to answer
+997 = Don't know
+999 = NIU (Not in universe)
+
+		
+Top codes:2003-2004:  80 years.
+2005 onward:  85 years.  Persons aged 80-84 are assigned a code of 80 and persons age 85+ are assigned a code of 85.]]></codInstr>
+  <concept vocab="IPUMS">Core Demographic Variables -- PERSON</concept>
+  <varFormat schema="other" type="numeric"/>
+</var>
+<var ID="SEX" dcml="0" files="ExtractData" intrvl="discrete" name="SEX" rectype="2">
+  <location EndPos="54" StartPos="53" width="2"/>
+  <labl>Sex</labl>
+  <txt><![CDATA[SEX reports whether the individual is male or female.
+
+SEX was collected at the time of the ATUS interview.  SEX_CPS8 was also collected at the time of the final CPS interview, 2-5 months before the ATUS interview.]]></txt>
+  <catgry>
+    <catValu>01</catValu>
+    <labl>Male</labl>
+  </catgry>
+  <catgry>
+    <catValu>02</catValu>
+    <labl>Female</labl>
+  </catgry>
+  <catgry>
+    <catValu>99</catValu>
+    <labl>NIU (Not in universe)</labl>
+  </catgry>
+  <concept vocab="IPUMS">Core Demographic Variables -- PERSON</concept>
+  <varFormat schema="other" type="numeric"/>
+</var>
+<var ID="ACTLINE" dcml="0" files="ExtractData" intrvl="contin" name="ACTLINE" rectype="3">
+  <location EndPos="29" StartPos="28" width="2"/>
+  <labl>Activity line number</labl>
+  <txt><![CDATA[ACTLINE is an identifying number for each activity record. Activity records can be uniquely identified using CASEID and ACTLINE.
+
+ACTLINE is also used with ACTLINEW to link who records to activity records.
+
+This variable is available via extracts that are hierarchical or rectangular (activity) (more info on extract formats). If you request a hierarchical extract and plan to construct time use variables in your statistics package, this variable may be useful to you. If you request a rectangular extract and plan to construct time use variables through the extract system, ACTLINE will not be included in your extract, as persons are the unit of observation for rectangular extracts rather than activity or who records.]]></txt>
+  <codInstr><![CDATA[CodesACTLINE is a 2-digit numeric variable identifying each activity record.]]></codInstr>
+  <concept vocab="IPUMS">Technical Activity Variables -- ACTIVITY</concept>
+  <varFormat schema="other" type="numeric"/>
+</var>
+<var ID="ACTIVITY" dcml="0" files="ExtractData" intrvl="discrete" name="ACTIVITY" rectype="3">
+  <location EndPos="35" StartPos="30" width="6"/>
+  <labl>Activity</labl>
+  <txt><![CDATA[ACTIVITY reports the respondent's activity.  
+
+The activity is recorded as a six digit number.  The first two digits correspond to a broad category, the middle two to a more detailed subcategory, and the final two to a specific activity within those categories.  For example, broad category 02 refers to "Household Activities."  Within "Household Activities," subcategory 01 refers to "Housework."  Within that subcategory, 02 refers to "Doing laundry."  The full six digit code for "Doing laundry" is therefore 020102.  Analyses can be done using the first two, the first four, or all six digits of ACTIVITY.
+
+There are a number of variables that may be used in conjunction with ACTIVITY.  START and STOP record the start and stop times of the activity, respectively.  DURATION records the number of minutes the activity lasted. DURATION_EXT also records the number of minutes the activity lasted, but does not truncate the last activity at 4:00 a.m. when the diary day ends.  WHERE records the location of activities. Finally, the variable RELATEW records who was with the respondent during the activity.  Users should note that "who" information is not collected for all activities (see WHO_ASK).
+
+There are a number of secondary activity variables that may be used in conjunction with activity. See more information on secondary childcare and secondary eating and drinking. 
+
+Users analyzing travel should be aware of how travel activities are coded in the ATUS. More information is available elsewhere.
+
+ACTIVITY is available via extracts that are hierarchical or rectangular (activity) (more info on extract formats). If you request a hierarchical extract and plan to construct time use variables in your statistics package, this variable may be useful to you. If you request a rectangular extract and plan to construct time use variables through the extract system, ACTIVITY will not be included in your extract, as persons are the unit of observation for rectangular extracts rather than activity or who records.]]></txt>
+  <catgry>
+    <catValu>010000</catValu>
+    <labl>Personal Care</labl>
+  </catgry>
+  <catgry>
+    <catValu>010100</catValu>
+    <labl>Sleeping</labl>
+  </catgry>
+  <catgry>
+    <catValu>010101</catValu>
+    <labl>Sleeping</labl>
+  </catgry>
+  <catgry>
+    <catValu>010102</catValu>
+    <labl>Sleeplessness</labl>
+  </catgry>
+  <catgry>
+    <catValu>010199</catValu>
+    <labl>Sleeping, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>010200</catValu>
+    <labl>Grooming</labl>
+  </catgry>
+  <catgry>
+    <catValu>010201</catValu>
+    <labl>Washing, dressing and grooming oneself</labl>
+  </catgry>
+  <catgry>
+    <catValu>010299</catValu>
+    <labl>Grooming, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>010300</catValu>
+    <labl>Health-Related Self Care</labl>
+  </catgry>
+  <catgry>
+    <catValu>010301</catValu>
+    <labl>Health-related self care</labl>
+  </catgry>
+  <catgry>
+    <catValu>010399</catValu>
+    <labl>Self care, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>010400</catValu>
+    <labl>Personal Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>010401</catValu>
+    <labl>Personal/Private activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>010499</catValu>
+    <labl>Personal activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>010500</catValu>
+    <labl>Personal Care Emergencies</labl>
+  </catgry>
+  <catgry>
+    <catValu>010501</catValu>
+    <labl>Personal emergencies</labl>
+  </catgry>
+  <catgry>
+    <catValu>010599</catValu>
+    <labl>Personal care emergencies, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>019900</catValu>
+    <labl>Personal Care, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>019999</catValu>
+    <labl>Personal care, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>020000</catValu>
+    <labl>Household Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>020100</catValu>
+    <labl>Housework</labl>
+  </catgry>
+  <catgry>
+    <catValu>020101</catValu>
+    <labl>Interior cleaning</labl>
+  </catgry>
+  <catgry>
+    <catValu>020102</catValu>
+    <labl>Laundry</labl>
+  </catgry>
+  <catgry>
+    <catValu>020103</catValu>
+    <labl>Sewing, repairing, and maintaining textiles</labl>
+  </catgry>
+  <catgry>
+    <catValu>020104</catValu>
+    <labl>Storing interior hh items, inc. food</labl>
+  </catgry>
+  <catgry>
+    <catValu>020199</catValu>
+    <labl>Housework, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>020200</catValu>
+    <labl>Food and Drink Preparation, Presentation, and Clean-up</labl>
+  </catgry>
+  <catgry>
+    <catValu>020201</catValu>
+    <labl>Food and drink preparation</labl>
+  </catgry>
+  <catgry>
+    <catValu>020202</catValu>
+    <labl>Food presentation</labl>
+  </catgry>
+  <catgry>
+    <catValu>020203</catValu>
+    <labl>Kitchen and food clean-up</labl>
+  </catgry>
+  <catgry>
+    <catValu>020299</catValu>
+    <labl>Food and drink prep, serving and clean-up, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>020300</catValu>
+    <labl>Interior Maintenance, Repair, and Decoration</labl>
+  </catgry>
+  <catgry>
+    <catValu>020301</catValu>
+    <labl>Interior arrangement, decoration, and repairs</labl>
+  </catgry>
+  <catgry>
+    <catValu>020302</catValu>
+    <labl>Building and repairing furniture</labl>
+  </catgry>
+  <catgry>
+    <catValu>020303</catValu>
+    <labl>Heating and cooling</labl>
+  </catgry>
+  <catgry>
+    <catValu>020399</catValu>
+    <labl>Interior maintenance, repair, and decoration, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>020400</catValu>
+    <labl>Exterior Maintenance, Repair, and Decoration</labl>
+  </catgry>
+  <catgry>
+    <catValu>020401</catValu>
+    <labl>Exterior cleaning</labl>
+  </catgry>
+  <catgry>
+    <catValu>020402</catValu>
+    <labl>Exterior repair, improvements, and decoration</labl>
+  </catgry>
+  <catgry>
+    <catValu>020499</catValu>
+    <labl>Exterior maintenance, repair and decoration, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>020500</catValu>
+    <labl>Lawn, Garden, and Houseplants</labl>
+  </catgry>
+  <catgry>
+    <catValu>020501</catValu>
+    <labl>Lawn, garden, and houseplant care</labl>
+  </catgry>
+  <catgry>
+    <catValu>020502</catValu>
+    <labl>Ponds, pools, and hot tubs</labl>
+  </catgry>
+  <catgry>
+    <catValu>020599</catValu>
+    <labl>Lawn and garden, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>020600</catValu>
+    <labl>Animals and Pets</labl>
+  </catgry>
+  <catgry>
+    <catValu>020601</catValu>
+    <labl>Care for animals and pets (not veterinary care)</labl>
+  </catgry>
+  <catgry>
+    <catValu>020602</catValu>
+    <labl>Care for animals and pets (not veterinary care) (2008+)</labl>
+  </catgry>
+  <catgry>
+    <catValu>020603</catValu>
+    <labl>Walking, exercising, playing with animals (2008+)</labl>
+  </catgry>
+  <catgry>
+    <catValu>020699</catValu>
+    <labl>Pet and animal care, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>020700</catValu>
+    <labl>Vehicles</labl>
+  </catgry>
+  <catgry>
+    <catValu>020701</catValu>
+    <labl>Vehicle repair and maintenance (by self)</labl>
+  </catgry>
+  <catgry>
+    <catValu>020799</catValu>
+    <labl>Vehicles, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>020800</catValu>
+    <labl>Appliances, Tools, and Toys</labl>
+  </catgry>
+  <catgry>
+    <catValu>020801</catValu>
+    <labl>App, tool, toy set-up, repair, and maint (by self)</labl>
+  </catgry>
+  <catgry>
+    <catValu>020899</catValu>
+    <labl>Appliances and tools, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>020900</catValu>
+    <labl>Household Management</labl>
+  </catgry>
+  <catgry>
+    <catValu>020901</catValu>
+    <labl>Financial management</labl>
+  </catgry>
+  <catgry>
+    <catValu>020902</catValu>
+    <labl>Household and personal organization and planning</labl>
+  </catgry>
+  <catgry>
+    <catValu>020903</catValu>
+    <labl>HH and personal mail and messages (except e-mail)</labl>
+  </catgry>
+  <catgry>
+    <catValu>020904</catValu>
+    <labl>HH and personal e-mail and messages</labl>
+  </catgry>
+  <catgry>
+    <catValu>020905</catValu>
+    <labl>Home security</labl>
+  </catgry>
+  <catgry>
+    <catValu>020999</catValu>
+    <labl>Household management, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>029900</catValu>
+    <labl>Household Activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>029999</catValu>
+    <labl>Household activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>030000</catValu>
+    <labl>Caring for and Helping Household Members</labl>
+  </catgry>
+  <catgry>
+    <catValu>030100</catValu>
+    <labl>Caring for and Helping Household Children</labl>
+  </catgry>
+  <catgry>
+    <catValu>030101</catValu>
+    <labl>Physical care for hh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>030102</catValu>
+    <labl>Reading to/with hh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>030103</catValu>
+    <labl>Playing with hh children, not sports</labl>
+  </catgry>
+  <catgry>
+    <catValu>030104</catValu>
+    <labl>Arts and crafts with hh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>030105</catValu>
+    <labl>Playing sports with hh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>030106</catValu>
+    <labl>Talking with/listening to hh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>030107</catValu>
+    <labl>Helping or teaching hh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>030108</catValu>
+    <labl>Organization and planning for hh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>030109</catValu>
+    <labl>Looking after hh children (as a primary activity)</labl>
+  </catgry>
+  <catgry>
+    <catValu>030110</catValu>
+    <labl>Attending hh children's events</labl>
+  </catgry>
+  <catgry>
+    <catValu>030111</catValu>
+    <labl>Waiting for/with hh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>030112</catValu>
+    <labl>Picking up/dropping off hh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>030199</catValu>
+    <labl>Caring for and helping hh children, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>030200</catValu>
+    <labl>Activities Related to Household Children's Education</labl>
+  </catgry>
+  <catgry>
+    <catValu>030201</catValu>
+    <labl>Homework (hh children)</labl>
+  </catgry>
+  <catgry>
+    <catValu>030202</catValu>
+    <labl>Meetings and school conferences (hh children)</labl>
+  </catgry>
+  <catgry>
+    <catValu>030203</catValu>
+    <labl>Home schooling of hh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>030204</catValu>
+    <labl>Waiting associated with hh children's education</labl>
+  </catgry>
+  <catgry>
+    <catValu>030299</catValu>
+    <labl>Activities related to hh child's education, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>030300</catValu>
+    <labl>Activities Related to Household Children's Health</labl>
+  </catgry>
+  <catgry>
+    <catValu>030301</catValu>
+    <labl>Providing medical care to hh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>030302</catValu>
+    <labl>Obtaining medical care for hh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>030303</catValu>
+    <labl>Waiting associated with hh children's health</labl>
+  </catgry>
+  <catgry>
+    <catValu>030399</catValu>
+    <labl>Activities related to hh child's health, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>030400</catValu>
+    <labl>Caring for Household Adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>030401</catValu>
+    <labl>Physical care for hh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>030402</catValu>
+    <labl>Looking after hh adult (as a primary activity)</labl>
+  </catgry>
+  <catgry>
+    <catValu>030403</catValu>
+    <labl>Providing medical care to hh adult</labl>
+  </catgry>
+  <catgry>
+    <catValu>030404</catValu>
+    <labl>Obtaining medical and care services for hh adult</labl>
+  </catgry>
+  <catgry>
+    <catValu>030405</catValu>
+    <labl>Waiting associated with caring for hh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>030499</catValu>
+    <labl>Caring for household adults, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>030500</catValu>
+    <labl>Helping Household Adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>030501</catValu>
+    <labl>Helping hh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>030502</catValu>
+    <labl>Organization and planning for hh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>030503</catValu>
+    <labl>Picking up/dropping off hh adult</labl>
+  </catgry>
+  <catgry>
+    <catValu>030504</catValu>
+    <labl>Waiting associated with helping hh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>030599</catValu>
+    <labl>Helping household adults, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>039900</catValu>
+    <labl>Caring for and Helping Household Members, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>039999</catValu>
+    <labl>Caring for and helping hh members, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>040000</catValu>
+    <labl>Caring for and Helping Non-Household Members</labl>
+  </catgry>
+  <catgry>
+    <catValu>040100</catValu>
+    <labl>Caring for and Helping Non-Household Children</labl>
+  </catgry>
+  <catgry>
+    <catValu>040101</catValu>
+    <labl>Physical care for nonhh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>040102</catValu>
+    <labl>Reading to/with nonhh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>040103</catValu>
+    <labl>Playing with nonhh children, not sports</labl>
+  </catgry>
+  <catgry>
+    <catValu>040104</catValu>
+    <labl>Arts and crafts with nonhh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>040105</catValu>
+    <labl>Playing sports with nonhh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>040106</catValu>
+    <labl>Talking with/listening to nonhh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>040107</catValu>
+    <labl>Helping or teaching nonhh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>040108</catValu>
+    <labl>Organization and planning for nonhh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>040109</catValu>
+    <labl>Looking after nonhh children (as primary activity)</labl>
+  </catgry>
+  <catgry>
+    <catValu>040110</catValu>
+    <labl>Attending nonhh children's events</labl>
+  </catgry>
+  <catgry>
+    <catValu>040111</catValu>
+    <labl>Waiting for/with nonhh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>040112</catValu>
+    <labl>Dropping off/picking up nonhh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>040199</catValu>
+    <labl>Caring for and helping nonhh children, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>040200</catValu>
+    <labl>Activities Related to Non-Household Children's Education</labl>
+  </catgry>
+  <catgry>
+    <catValu>040201</catValu>
+    <labl>Homework (nonhh children)</labl>
+  </catgry>
+  <catgry>
+    <catValu>040202</catValu>
+    <labl>Mtgs and school conferences (nonhh children)</labl>
+  </catgry>
+  <catgry>
+    <catValu>040203</catValu>
+    <labl>Home schooling of nonhh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>040204</catValu>
+    <labl>Waiting assoc w/ nonhh children's education</labl>
+  </catgry>
+  <catgry>
+    <catValu>040299</catValu>
+    <labl>Activities related to nonhh child's educ., n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>040300</catValu>
+    <labl>Activities Related to Non-Household Children's Health</labl>
+  </catgry>
+  <catgry>
+    <catValu>040301</catValu>
+    <labl>Providing medical care to nonhh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>040302</catValu>
+    <labl>Obtaining medical care for nonhh children</labl>
+  </catgry>
+  <catgry>
+    <catValu>040303</catValu>
+    <labl>Waiting associated with nonhh children's health</labl>
+  </catgry>
+  <catgry>
+    <catValu>040399</catValu>
+    <labl>Activities related to nonhh child's health, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>040400</catValu>
+    <labl>Caring for Non-Household Adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>040401</catValu>
+    <labl>Physical care for nonhh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>040402</catValu>
+    <labl>Looking after nonhh adult (as a primary activity)</labl>
+  </catgry>
+  <catgry>
+    <catValu>040403</catValu>
+    <labl>Providing medical care to nonhh adult</labl>
+  </catgry>
+  <catgry>
+    <catValu>040404</catValu>
+    <labl>Obtaining medical and care svcs for nonhh adult</labl>
+  </catgry>
+  <catgry>
+    <catValu>040405</catValu>
+    <labl>Waiting associated with caring for nonhh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>040499</catValu>
+    <labl>Caring for nonhh adults, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>040500</catValu>
+    <labl>Helping Non-Household Adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>040501</catValu>
+    <labl>Hswrk, cooking, and shopping asst, nonhh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>040502</catValu>
+    <labl>House and lawn maint and repair asst, nonhh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>040503</catValu>
+    <labl>Animal and pet care assistance for nonhh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>040504</catValu>
+    <labl>Vehicle/appliance maint/repair asst, nonhh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>040505</catValu>
+    <labl>Financial mgmt asst for nonhh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>040506</catValu>
+    <labl>HH mgmt and paperwork asst, nonhh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>040507</catValu>
+    <labl>Picking up/dropping off nonhh adult</labl>
+  </catgry>
+  <catgry>
+    <catValu>040508</catValu>
+    <labl>Waiting associated with helping nonhh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>040599</catValu>
+    <labl>Helping nonhh adults, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>049900</catValu>
+    <labl>Caring for and Helping Non-Household Members, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>049999</catValu>
+    <labl>Caring for and helping nonhh members, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>050000</catValu>
+    <labl>Work and Work-Related Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>050100</catValu>
+    <labl>Working</labl>
+  </catgry>
+  <catgry>
+    <catValu>050101</catValu>
+    <labl>Work, main job</labl>
+  </catgry>
+  <catgry>
+    <catValu>050102</catValu>
+    <labl>Work, other job(s)</labl>
+  </catgry>
+  <catgry>
+    <catValu>050103</catValu>
+    <labl>Security procedures related to work</labl>
+  </catgry>
+  <catgry>
+    <catValu>050104</catValu>
+    <labl>Waiting associated with working</labl>
+  </catgry>
+  <catgry>
+    <catValu>050199</catValu>
+    <labl>Working, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>050200</catValu>
+    <labl>Work-Related Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>050201</catValu>
+    <labl>Socializing, relaxing, and leisure as part of job</labl>
+  </catgry>
+  <catgry>
+    <catValu>050202</catValu>
+    <labl>Eating and drinking as part of job</labl>
+  </catgry>
+  <catgry>
+    <catValu>050203</catValu>
+    <labl>Sports and exercise as part of job</labl>
+  </catgry>
+  <catgry>
+    <catValu>050204</catValu>
+    <labl>Security procedures as part of job</labl>
+  </catgry>
+  <catgry>
+    <catValu>050205</catValu>
+    <labl>Waiting associated with work-related activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>050299</catValu>
+    <labl>Work-related activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>050300</catValu>
+    <labl>Other Income-Generating Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>050301</catValu>
+    <labl>Income-generating hobbies, crafts, and food</labl>
+  </catgry>
+  <catgry>
+    <catValu>050302</catValu>
+    <labl>Income-generating performances</labl>
+  </catgry>
+  <catgry>
+    <catValu>050303</catValu>
+    <labl>Income-generating services</labl>
+  </catgry>
+  <catgry>
+    <catValu>050304</catValu>
+    <labl>Income-generating rental property activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>050305</catValu>
+    <labl>Waiting assoc w/other income-generating acts</labl>
+  </catgry>
+  <catgry>
+    <catValu>050399</catValu>
+    <labl>Other income-generating activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>050400</catValu>
+    <labl>Job Search and Interviewing</labl>
+  </catgry>
+  <catgry>
+    <catValu>050401</catValu>
+    <labl>Job search activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>050403</catValu>
+    <labl>Job interviewing</labl>
+  </catgry>
+  <catgry>
+    <catValu>050404</catValu>
+    <labl>Waiting associated with job search or interview</labl>
+  </catgry>
+  <catgry>
+    <catValu>050405</catValu>
+    <labl>Sec. procedures rel. to job search/interviewing</labl>
+  </catgry>
+  <catgry>
+    <catValu>050499</catValu>
+    <labl>Job search and Interviewing, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>059900</catValu>
+    <labl>Work and Work-Related Activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>059999</catValu>
+    <labl>Work and work-related activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>060000</catValu>
+    <labl>Education</labl>
+  </catgry>
+  <catgry>
+    <catValu>060100</catValu>
+    <labl>Taking Class</labl>
+  </catgry>
+  <catgry>
+    <catValu>060101</catValu>
+    <labl>Taking class for degree, certification, or lic</labl>
+  </catgry>
+  <catgry>
+    <catValu>060102</catValu>
+    <labl>Taking class for personal interest</labl>
+  </catgry>
+  <catgry>
+    <catValu>060103</catValu>
+    <labl>Waiting associated with taking classes</labl>
+  </catgry>
+  <catgry>
+    <catValu>060104</catValu>
+    <labl>Security procedures rel. to taking classes</labl>
+  </catgry>
+  <catgry>
+    <catValu>060199</catValu>
+    <labl>Taking class, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>060200</catValu>
+    <labl>Extracurricular School Activities (except sports)</labl>
+  </catgry>
+  <catgry>
+    <catValu>060201</catValu>
+    <labl>Extracurricular club activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>060202</catValu>
+    <labl>Extracurricular music and performance activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>060203</catValu>
+    <labl>Extracurricular student government activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>060204</catValu>
+    <labl>Waiting associated with extracurricular activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>060299</catValu>
+    <labl>Education-related extracurricular activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>060300</catValu>
+    <labl>Research or Homework</labl>
+  </catgry>
+  <catgry>
+    <catValu>060301</catValu>
+    <labl>Rsrch/HW for class for degree, cert, or lic</labl>
+  </catgry>
+  <catgry>
+    <catValu>060302</catValu>
+    <labl>Research/homework for class for pers. interest</labl>
+  </catgry>
+  <catgry>
+    <catValu>060303</catValu>
+    <labl>Waiting associated with research/homework</labl>
+  </catgry>
+  <catgry>
+    <catValu>060399</catValu>
+    <labl>Research/homework n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>060400</catValu>
+    <labl>Registration or Administrative Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>060401</catValu>
+    <labl>Admin activities: class for degree, cert, or lic</labl>
+  </catgry>
+  <catgry>
+    <catValu>060402</catValu>
+    <labl>Admin activities: class for personal interest</labl>
+  </catgry>
+  <catgry>
+    <catValu>060403</catValu>
+    <labl>Waiting assoc w/admin. activities (education)</labl>
+  </catgry>
+  <catgry>
+    <catValu>060499</catValu>
+    <labl>Administrative for education, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>069900</catValu>
+    <labl>Education, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>069999</catValu>
+    <labl>Education, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>070000</catValu>
+    <labl>Consumer Purchases</labl>
+  </catgry>
+  <catgry>
+    <catValu>070100</catValu>
+    <labl>Shopping (store, telephone, internet)</labl>
+  </catgry>
+  <catgry>
+    <catValu>070101</catValu>
+    <labl>Grocery shopping</labl>
+  </catgry>
+  <catgry>
+    <catValu>070102</catValu>
+    <labl>Purchasing gas</labl>
+  </catgry>
+  <catgry>
+    <catValu>070103</catValu>
+    <labl>Purchasing food (not groceries)</labl>
+  </catgry>
+  <catgry>
+    <catValu>070104</catValu>
+    <labl>Shopping, except groceries, food and gas</labl>
+  </catgry>
+  <catgry>
+    <catValu>070105</catValu>
+    <labl>Waiting associated with shopping</labl>
+  </catgry>
+  <catgry>
+    <catValu>070199</catValu>
+    <labl>Shopping, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>070200</catValu>
+    <labl>Researching Purchases</labl>
+  </catgry>
+  <catgry>
+    <catValu>070201</catValu>
+    <labl>Comparison shopping</labl>
+  </catgry>
+  <catgry>
+    <catValu>070299</catValu>
+    <labl>Researching purchases, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>070300</catValu>
+    <labl>Security Procedures Related to Consumer Purchases</labl>
+  </catgry>
+  <catgry>
+    <catValu>070301</catValu>
+    <labl>Security procedures rel. to consumer purchases</labl>
+  </catgry>
+  <catgry>
+    <catValu>070399</catValu>
+    <labl>Sec procedures rel. to cons purchases, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>079900</catValu>
+    <labl>Consumer Purchases, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>079999</catValu>
+    <labl>Consumer purchases, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>080000</catValu>
+    <labl>Professional and Personal Care Services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080100</catValu>
+    <labl>Childcare Services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080101</catValu>
+    <labl>Using paid childcare services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080102</catValu>
+    <labl>Waiting associated w/purchasing childcare svcs</labl>
+  </catgry>
+  <catgry>
+    <catValu>080199</catValu>
+    <labl>Using paid childcare services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>080200</catValu>
+    <labl>Financial Services and Banking</labl>
+  </catgry>
+  <catgry>
+    <catValu>080201</catValu>
+    <labl>Banking</labl>
+  </catgry>
+  <catgry>
+    <catValu>080202</catValu>
+    <labl>Using other financial services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080203</catValu>
+    <labl>Waiting associated w/banking/financial services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080299</catValu>
+    <labl>Using financial services and banking, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>080300</catValu>
+    <labl>Legal Services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080301</catValu>
+    <labl>Using legal services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080302</catValu>
+    <labl>Waiting associated with legal services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080399</catValu>
+    <labl>Using legal services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>080400</catValu>
+    <labl>Medical and Care Services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080401</catValu>
+    <labl>Using health and care services outside the home</labl>
+  </catgry>
+  <catgry>
+    <catValu>080402</catValu>
+    <labl>Using in-home health and care services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080403</catValu>
+    <labl>Waiting associated with medical services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080499</catValu>
+    <labl>Using medical services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>080500</catValu>
+    <labl>Personal Care Services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080501</catValu>
+    <labl>Using personal care services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080502</catValu>
+    <labl>Waiting associated w/personal care services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080599</catValu>
+    <labl>Using personal care services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>080600</catValu>
+    <labl>Real Estate</labl>
+  </catgry>
+  <catgry>
+    <catValu>080601</catValu>
+    <labl>Activities rel. to purchasing/selling real estate</labl>
+  </catgry>
+  <catgry>
+    <catValu>080602</catValu>
+    <labl>Waiting assoc w/purchasing/selling real estate</labl>
+  </catgry>
+  <catgry>
+    <catValu>080699</catValu>
+    <labl>Using real estate services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>080700</catValu>
+    <labl>Veterinary Services (excluding grooming)</labl>
+  </catgry>
+  <catgry>
+    <catValu>080701</catValu>
+    <labl>Using veterinary services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080702</catValu>
+    <labl>Waiting associated with veterinary services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080799</catValu>
+    <labl>Using veterinary services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>080800</catValu>
+    <labl>Security Procedures Related to Professional or Personal Services</labl>
+  </catgry>
+  <catgry>
+    <catValu>080801</catValu>
+    <labl>Security procedures rel. to prof/personal svcs.</labl>
+  </catgry>
+  <catgry>
+    <catValu>080899</catValu>
+    <labl>Sec procedures rel. to prof/personal svcs n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>089900</catValu>
+    <labl>Professional and Personal Services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>089999</catValu>
+    <labl>Professional and personal services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>090000</catValu>
+    <labl>Household Services</labl>
+  </catgry>
+  <catgry>
+    <catValu>090100</catValu>
+    <labl>Household Services (not done by self)</labl>
+  </catgry>
+  <catgry>
+    <catValu>090101</catValu>
+    <labl>Using interior cleaning services</labl>
+  </catgry>
+  <catgry>
+    <catValu>090102</catValu>
+    <labl>Using meal preparation services</labl>
+  </catgry>
+  <catgry>
+    <catValu>090103</catValu>
+    <labl>Using clothing repair and cleaning services</labl>
+  </catgry>
+  <catgry>
+    <catValu>090104</catValu>
+    <labl>Waiting associated with using household services</labl>
+  </catgry>
+  <catgry>
+    <catValu>090199</catValu>
+    <labl>Using household services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>090200</catValu>
+    <labl>Home Maintenance, Repair, Decoration, and Construction (not done by self)</labl>
+  </catgry>
+  <catgry>
+    <catValu>090201</catValu>
+    <labl>Using home maint/repair/décor/construction svcs</labl>
+  </catgry>
+  <catgry>
+    <catValu>090202</catValu>
+    <labl>Wtg assoc w/ home main/repair/décor/constr</labl>
+  </catgry>
+  <catgry>
+    <catValu>090299</catValu>
+    <labl>Using home maint/repair/décor/constr svcs n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>090300</catValu>
+    <labl>Pet Services (not done by self and not veterinary care)</labl>
+  </catgry>
+  <catgry>
+    <catValu>090301</catValu>
+    <labl>Using pet services</labl>
+  </catgry>
+  <catgry>
+    <catValu>090302</catValu>
+    <labl>Waiting associated with pet services</labl>
+  </catgry>
+  <catgry>
+    <catValu>090399</catValu>
+    <labl>Using pet services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>090400</catValu>
+    <labl>Lawn and Garden Services (not done by self)</labl>
+  </catgry>
+  <catgry>
+    <catValu>090401</catValu>
+    <labl>Using lawn and garden services</labl>
+  </catgry>
+  <catgry>
+    <catValu>090402</catValu>
+    <labl>Waiting assoc with using lawn and garden svcs</labl>
+  </catgry>
+  <catgry>
+    <catValu>090499</catValu>
+    <labl>Using lawn and garden services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>090500</catValu>
+    <labl>Vehicle Maintenance and Repair Services (not done by self)</labl>
+  </catgry>
+  <catgry>
+    <catValu>090501</catValu>
+    <labl>Using vehicle maintenance or repair services</labl>
+  </catgry>
+  <catgry>
+    <catValu>090502</catValu>
+    <labl>Waiting assoc with vehicle main. or repair svcs</labl>
+  </catgry>
+  <catgry>
+    <catValu>090599</catValu>
+    <labl>Using vehicle maint. and repair svcs, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>099900</catValu>
+    <labl>Household Services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>099999</catValu>
+    <labl>Using household services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>100000</catValu>
+    <labl>Government Services and Civic Obligations</labl>
+  </catgry>
+  <catgry>
+    <catValu>100100</catValu>
+    <labl>Using Government Services</labl>
+  </catgry>
+  <catgry>
+    <catValu>100101</catValu>
+    <labl>Using police and fire services</labl>
+  </catgry>
+  <catgry>
+    <catValu>100102</catValu>
+    <labl>Using social services</labl>
+  </catgry>
+  <catgry>
+    <catValu>100103</catValu>
+    <labl>Obtaining licenses and paying fines, fees, taxes</labl>
+  </catgry>
+  <catgry>
+    <catValu>100199</catValu>
+    <labl>Using government services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>100200</catValu>
+    <labl>Civic Obligations and Participation</labl>
+  </catgry>
+  <catgry>
+    <catValu>100201</catValu>
+    <labl>Civic obligations and participation</labl>
+  </catgry>
+  <catgry>
+    <catValu>100299</catValu>
+    <labl>Civic obligations and participation, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>100300</catValu>
+    <labl>Waiting Associated with Government Services or Civic Obligations</labl>
+  </catgry>
+  <catgry>
+    <catValu>100303</catValu>
+    <labl>Waiting assoc w/civic obligations and participation</labl>
+  </catgry>
+  <catgry>
+    <catValu>100304</catValu>
+    <labl>Waiting associated with using government services</labl>
+  </catgry>
+  <catgry>
+    <catValu>100399</catValu>
+    <labl>Wtg assoc w/govt svcs or civic obligations, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>100400</catValu>
+    <labl>Security Procedures Related to Government Services or Civic Obligations</labl>
+  </catgry>
+  <catgry>
+    <catValu>100401</catValu>
+    <labl>Sec procedures rel. to govt svcs/civic obligations</labl>
+  </catgry>
+  <catgry>
+    <catValu>100499</catValu>
+    <labl>Sec procs rel. to govt svcs/civic obligations, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>109900</catValu>
+    <labl>Government Services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>109999</catValu>
+    <labl>Government services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>110000</catValu>
+    <labl>Eating and Drinking</labl>
+  </catgry>
+  <catgry>
+    <catValu>110100</catValu>
+    <labl>Eating and Drinking</labl>
+  </catgry>
+  <catgry>
+    <catValu>110101</catValu>
+    <labl>Eating and drinking</labl>
+  </catgry>
+  <catgry>
+    <catValu>110199</catValu>
+    <labl>Eating and drinking, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>110200</catValu>
+    <labl>Waiting Associated with Eating and Drinking</labl>
+  </catgry>
+  <catgry>
+    <catValu>110201</catValu>
+    <labl>Waiting associated w/eating and drinking</labl>
+  </catgry>
+  <catgry>
+    <catValu>110299</catValu>
+    <labl>Waiting associated with eating and drinking, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>119900</catValu>
+    <labl>Eating and Drinking, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>119999</catValu>
+    <labl>Eating and drinking, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>120000</catValu>
+    <labl>Socializing, Relaxing, and Leisure</labl>
+  </catgry>
+  <catgry>
+    <catValu>120100</catValu>
+    <labl>Socializing and Communicating</labl>
+  </catgry>
+  <catgry>
+    <catValu>120101</catValu>
+    <labl>Socializing and communicating with others</labl>
+  </catgry>
+  <catgry>
+    <catValu>120199</catValu>
+    <labl>Socializing and communicating, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>120200</catValu>
+    <labl>Attending or Hosting Social Events</labl>
+  </catgry>
+  <catgry>
+    <catValu>120201</catValu>
+    <labl>Attending or hosting parties/receptions/ceremonies</labl>
+  </catgry>
+  <catgry>
+    <catValu>120202</catValu>
+    <labl>Attending meetings for personal interest (not volunteering)</labl>
+  </catgry>
+  <catgry>
+    <catValu>120299</catValu>
+    <labl>Attending/hosting social events, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>120300</catValu>
+    <labl>Relaxing and Leisure</labl>
+  </catgry>
+  <catgry>
+    <catValu>120301</catValu>
+    <labl>Relaxing, thinking</labl>
+  </catgry>
+  <catgry>
+    <catValu>120302</catValu>
+    <labl>Tobacco and drug use</labl>
+  </catgry>
+  <catgry>
+    <catValu>120303</catValu>
+    <labl>Television and movies (not religious)</labl>
+  </catgry>
+  <catgry>
+    <catValu>120304</catValu>
+    <labl>Television (religious)</labl>
+  </catgry>
+  <catgry>
+    <catValu>120305</catValu>
+    <labl>Listening to the radio</labl>
+  </catgry>
+  <catgry>
+    <catValu>120306</catValu>
+    <labl>Listening to/playing music (not radio)</labl>
+  </catgry>
+  <catgry>
+    <catValu>120307</catValu>
+    <labl>Playing games</labl>
+  </catgry>
+  <catgry>
+    <catValu>120308</catValu>
+    <labl>Computer use for leisure (exc. Games)</labl>
+  </catgry>
+  <catgry>
+    <catValu>120309</catValu>
+    <labl>Arts and crafts as a hobby</labl>
+  </catgry>
+  <catgry>
+    <catValu>120310</catValu>
+    <labl>Collecting as a hobby</labl>
+  </catgry>
+  <catgry>
+    <catValu>120311</catValu>
+    <labl>Hobbies, except arts and crafts and collecting</labl>
+  </catgry>
+  <catgry>
+    <catValu>120312</catValu>
+    <labl>Reading for personal interest</labl>
+  </catgry>
+  <catgry>
+    <catValu>120313</catValu>
+    <labl>Writing for personal interest</labl>
+  </catgry>
+  <catgry>
+    <catValu>120399</catValu>
+    <labl>Relaxing and leisure, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>120400</catValu>
+    <labl>Arts and Entertainment (other than sports)</labl>
+  </catgry>
+  <catgry>
+    <catValu>120401</catValu>
+    <labl>Attending performing arts</labl>
+  </catgry>
+  <catgry>
+    <catValu>120402</catValu>
+    <labl>Attending museums</labl>
+  </catgry>
+  <catgry>
+    <catValu>120403</catValu>
+    <labl>Attending movies/film</labl>
+  </catgry>
+  <catgry>
+    <catValu>120404</catValu>
+    <labl>Attending gambling establishments</labl>
+  </catgry>
+  <catgry>
+    <catValu>120405</catValu>
+    <labl>Security procedures rel. to arts and entertainment</labl>
+  </catgry>
+  <catgry>
+    <catValu>120499</catValu>
+    <labl>Arts and entertainment, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>120500</catValu>
+    <labl>Waiting Associated with Socializing, Relaxing, and Leisure</labl>
+  </catgry>
+  <catgry>
+    <catValu>120501</catValu>
+    <labl>Waiting assoc. w/socializing and communicating</labl>
+  </catgry>
+  <catgry>
+    <catValu>120502</catValu>
+    <labl>Waiting assoc. w/attending/hosting social events</labl>
+  </catgry>
+  <catgry>
+    <catValu>120503</catValu>
+    <labl>Waiting associated with relaxing/leisure</labl>
+  </catgry>
+  <catgry>
+    <catValu>120504</catValu>
+    <labl>Waiting associated with arts and entertainment</labl>
+  </catgry>
+  <catgry>
+    <catValu>120599</catValu>
+    <labl>Waiting associated with socializing, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>129900</catValu>
+    <labl>Socializing, Relaxing, and Leisure, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>129999</catValu>
+    <labl>Socializing, relaxing, and leisure, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>130000</catValu>
+    <labl>Sports, Exercise, and Recreation</labl>
+  </catgry>
+  <catgry>
+    <catValu>130100</catValu>
+    <labl>Participating in Sports, Exercise, or Recreation</labl>
+  </catgry>
+  <catgry>
+    <catValu>130101</catValu>
+    <labl>Doing aerobics</labl>
+  </catgry>
+  <catgry>
+    <catValu>130102</catValu>
+    <labl>Playing baseball</labl>
+  </catgry>
+  <catgry>
+    <catValu>130103</catValu>
+    <labl>Playing basketball</labl>
+  </catgry>
+  <catgry>
+    <catValu>130104</catValu>
+    <labl>Biking</labl>
+  </catgry>
+  <catgry>
+    <catValu>130105</catValu>
+    <labl>Playing billiards</labl>
+  </catgry>
+  <catgry>
+    <catValu>130106</catValu>
+    <labl>Boating</labl>
+  </catgry>
+  <catgry>
+    <catValu>130107</catValu>
+    <labl>Bowling</labl>
+  </catgry>
+  <catgry>
+    <catValu>130108</catValu>
+    <labl>Climbing, spelunking, caving</labl>
+  </catgry>
+  <catgry>
+    <catValu>130109</catValu>
+    <labl>Dancing</labl>
+  </catgry>
+  <catgry>
+    <catValu>130110</catValu>
+    <labl>Participating in equestrian sports</labl>
+  </catgry>
+  <catgry>
+    <catValu>130111</catValu>
+    <labl>Fencing</labl>
+  </catgry>
+  <catgry>
+    <catValu>130112</catValu>
+    <labl>Fishing</labl>
+  </catgry>
+  <catgry>
+    <catValu>130113</catValu>
+    <labl>Playing football</labl>
+  </catgry>
+  <catgry>
+    <catValu>130114</catValu>
+    <labl>Golfing</labl>
+  </catgry>
+  <catgry>
+    <catValu>130115</catValu>
+    <labl>Doing gymnastics</labl>
+  </catgry>
+  <catgry>
+    <catValu>130116</catValu>
+    <labl>Hiking</labl>
+  </catgry>
+  <catgry>
+    <catValu>130117</catValu>
+    <labl>Playing hockey</labl>
+  </catgry>
+  <catgry>
+    <catValu>130118</catValu>
+    <labl>Hunting</labl>
+  </catgry>
+  <catgry>
+    <catValu>130119</catValu>
+    <labl>Participating in martial arts</labl>
+  </catgry>
+  <catgry>
+    <catValu>130120</catValu>
+    <labl>Playing racquet sports</labl>
+  </catgry>
+  <catgry>
+    <catValu>130121</catValu>
+    <labl>Participating in rodeo competitions</labl>
+  </catgry>
+  <catgry>
+    <catValu>130122</catValu>
+    <labl>Rollerblading</labl>
+  </catgry>
+  <catgry>
+    <catValu>130123</catValu>
+    <labl>Playing rugby</labl>
+  </catgry>
+  <catgry>
+    <catValu>130124</catValu>
+    <labl>Running</labl>
+  </catgry>
+  <catgry>
+    <catValu>130125</catValu>
+    <labl>Skiing, ice skating, snowboarding</labl>
+  </catgry>
+  <catgry>
+    <catValu>130126</catValu>
+    <labl>Playing soccer</labl>
+  </catgry>
+  <catgry>
+    <catValu>130127</catValu>
+    <labl>Playing softball</labl>
+  </catgry>
+  <catgry>
+    <catValu>130128</catValu>
+    <labl>Using cardiovascular equipment</labl>
+  </catgry>
+  <catgry>
+    <catValu>130129</catValu>
+    <labl>Vehicle touring/racing</labl>
+  </catgry>
+  <catgry>
+    <catValu>130130</catValu>
+    <labl>Playing volleyball</labl>
+  </catgry>
+  <catgry>
+    <catValu>130131</catValu>
+    <labl>Walking</labl>
+  </catgry>
+  <catgry>
+    <catValu>130132</catValu>
+    <labl>Participating in water sports</labl>
+  </catgry>
+  <catgry>
+    <catValu>130133</catValu>
+    <labl>Weightlifting/strength training</labl>
+  </catgry>
+  <catgry>
+    <catValu>130134</catValu>
+    <labl>Working out, unspecified</labl>
+  </catgry>
+  <catgry>
+    <catValu>130135</catValu>
+    <labl>Wrestling</labl>
+  </catgry>
+  <catgry>
+    <catValu>130136</catValu>
+    <labl>Doing yoga</labl>
+  </catgry>
+  <catgry>
+    <catValu>130199</catValu>
+    <labl>Playing sports n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>130200</catValu>
+    <labl>Attending Sports or Recreational Events</labl>
+  </catgry>
+  <catgry>
+    <catValu>130201</catValu>
+    <labl>Watching aerobics</labl>
+  </catgry>
+  <catgry>
+    <catValu>130202</catValu>
+    <labl>Watching baseball</labl>
+  </catgry>
+  <catgry>
+    <catValu>130203</catValu>
+    <labl>Watching basketball</labl>
+  </catgry>
+  <catgry>
+    <catValu>130204</catValu>
+    <labl>Watching biking</labl>
+  </catgry>
+  <catgry>
+    <catValu>130205</catValu>
+    <labl>Watching billiards</labl>
+  </catgry>
+  <catgry>
+    <catValu>130206</catValu>
+    <labl>Watching boating</labl>
+  </catgry>
+  <catgry>
+    <catValu>130207</catValu>
+    <labl>Watching bowling</labl>
+  </catgry>
+  <catgry>
+    <catValu>130208</catValu>
+    <labl>Watching climbing, spelunking, caving</labl>
+  </catgry>
+  <catgry>
+    <catValu>130209</catValu>
+    <labl>Watching dancing</labl>
+  </catgry>
+  <catgry>
+    <catValu>130210</catValu>
+    <labl>Watching equestrian sports</labl>
+  </catgry>
+  <catgry>
+    <catValu>130211</catValu>
+    <labl>Watching fencing</labl>
+  </catgry>
+  <catgry>
+    <catValu>130212</catValu>
+    <labl>Watching fishing</labl>
+  </catgry>
+  <catgry>
+    <catValu>130213</catValu>
+    <labl>Watching football</labl>
+  </catgry>
+  <catgry>
+    <catValu>130214</catValu>
+    <labl>Watching golfing</labl>
+  </catgry>
+  <catgry>
+    <catValu>130215</catValu>
+    <labl>Watching gymnastics</labl>
+  </catgry>
+  <catgry>
+    <catValu>130216</catValu>
+    <labl>Watching hockey</labl>
+  </catgry>
+  <catgry>
+    <catValu>130217</catValu>
+    <labl>Watching martial arts</labl>
+  </catgry>
+  <catgry>
+    <catValu>130218</catValu>
+    <labl>Watching racquet sports</labl>
+  </catgry>
+  <catgry>
+    <catValu>130219</catValu>
+    <labl>Watching rodeo competitions</labl>
+  </catgry>
+  <catgry>
+    <catValu>130220</catValu>
+    <labl>Watching rollerblading</labl>
+  </catgry>
+  <catgry>
+    <catValu>130221</catValu>
+    <labl>Watching rugby</labl>
+  </catgry>
+  <catgry>
+    <catValu>130222</catValu>
+    <labl>Watching running</labl>
+  </catgry>
+  <catgry>
+    <catValu>130223</catValu>
+    <labl>Watching skiing, ice skating, snowboarding</labl>
+  </catgry>
+  <catgry>
+    <catValu>130224</catValu>
+    <labl>Watching soccer</labl>
+  </catgry>
+  <catgry>
+    <catValu>130225</catValu>
+    <labl>Watching softball</labl>
+  </catgry>
+  <catgry>
+    <catValu>130226</catValu>
+    <labl>Watching vehicle touring/racing</labl>
+  </catgry>
+  <catgry>
+    <catValu>130227</catValu>
+    <labl>Watching volleyball</labl>
+  </catgry>
+  <catgry>
+    <catValu>130228</catValu>
+    <labl>Watching walking</labl>
+  </catgry>
+  <catgry>
+    <catValu>130229</catValu>
+    <labl>Watching water sports</labl>
+  </catgry>
+  <catgry>
+    <catValu>130230</catValu>
+    <labl>Watching weightlifting/strength training</labl>
+  </catgry>
+  <catgry>
+    <catValu>130231</catValu>
+    <labl>Watching people working out, unspecified</labl>
+  </catgry>
+  <catgry>
+    <catValu>130232</catValu>
+    <labl>Watching wrestling</labl>
+  </catgry>
+  <catgry>
+    <catValu>130299</catValu>
+    <labl>Attending sporting events, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>130300</catValu>
+    <labl>Waiting Associated with Sports, Exercise, and Recreation</labl>
+  </catgry>
+  <catgry>
+    <catValu>130301</catValu>
+    <labl>Waiting related to playing sports or exercising</labl>
+  </catgry>
+  <catgry>
+    <catValu>130302</catValu>
+    <labl>Waiting related to attending sporting events</labl>
+  </catgry>
+  <catgry>
+    <catValu>130399</catValu>
+    <labl>Wtg assoc with sports, exercise, and rec, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>130400</catValu>
+    <labl>Security Procedures Related to Sports, Exercise, and Recreation</labl>
+  </catgry>
+  <catgry>
+    <catValu>130401</catValu>
+    <labl>Security related to playing sports or exercising</labl>
+  </catgry>
+  <catgry>
+    <catValu>130402</catValu>
+    <labl>Security related to attending sporting events</labl>
+  </catgry>
+  <catgry>
+    <catValu>130499</catValu>
+    <labl>Sec related to sports, exercise, and rec, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>139900</catValu>
+    <labl>Sports, Exercise, and Recreation, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>139999</catValu>
+    <labl>Sports, exercise, and recreation, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>140000</catValu>
+    <labl>Religious and Spiritual Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>140100</catValu>
+    <labl>Religious or Spiritual Practices</labl>
+  </catgry>
+  <catgry>
+    <catValu>140101</catValu>
+    <labl>Attending religious services</labl>
+  </catgry>
+  <catgry>
+    <catValu>140102</catValu>
+    <labl>Participation in religious practices</labl>
+  </catgry>
+  <catgry>
+    <catValu>140103</catValu>
+    <labl>Waiting assoc w/religious and spiritual activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>140104</catValu>
+    <labl>Sec procedures rel. to relig and spiritual activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>140105</catValu>
+    <labl>Religious education activities (2007+)</labl>
+  </catgry>
+  <catgry>
+    <catValu>149900</catValu>
+    <labl>Religious and Spiritual Activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>149999</catValu>
+    <labl>Religious and spiritual activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>150000</catValu>
+    <labl>Volunteer Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>150100</catValu>
+    <labl>Administrative and Support Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>150101</catValu>
+    <labl>Computer use</labl>
+  </catgry>
+  <catgry>
+    <catValu>150102</catValu>
+    <labl>Organizing and preparing</labl>
+  </catgry>
+  <catgry>
+    <catValu>150103</catValu>
+    <labl>Reading</labl>
+  </catgry>
+  <catgry>
+    <catValu>150104</catValu>
+    <labl>Telephone calls (except hotline counseling)</labl>
+  </catgry>
+  <catgry>
+    <catValu>150105</catValu>
+    <labl>Writing</labl>
+  </catgry>
+  <catgry>
+    <catValu>150106</catValu>
+    <labl>Fundraising</labl>
+  </catgry>
+  <catgry>
+    <catValu>150199</catValu>
+    <labl>Administrative and support activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>150200</catValu>
+    <labl>Social Service and Care Activities (except medical)</labl>
+  </catgry>
+  <catgry>
+    <catValu>150201</catValu>
+    <labl>Food preparation, presentation, clean-up</labl>
+  </catgry>
+  <catgry>
+    <catValu>150202</catValu>
+    <labl>Collecting and delivering clothing and other goods</labl>
+  </catgry>
+  <catgry>
+    <catValu>150203</catValu>
+    <labl>Providing care</labl>
+  </catgry>
+  <catgry>
+    <catValu>150204</catValu>
+    <labl>Teaching, leading, counseling, mentoring</labl>
+  </catgry>
+  <catgry>
+    <catValu>150299</catValu>
+    <labl>Social service and care activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>150300</catValu>
+    <labl>Indoor and Outdoor Maintenance, Building, and Clean-Up Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>150301</catValu>
+    <labl>Building houses, wildlife sites, and other structures</labl>
+  </catgry>
+  <catgry>
+    <catValu>150302</catValu>
+    <labl>Indoor and outdoor maintenance, repair, and clean-up</labl>
+  </catgry>
+  <catgry>
+    <catValu>150399</catValu>
+    <labl>Indoor and outdoor maint, bldg and clean-up, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>150400</catValu>
+    <labl>Participating in Performance and Cultural Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>150401</catValu>
+    <labl>Performing</labl>
+  </catgry>
+  <catgry>
+    <catValu>150402</catValu>
+    <labl>Serving at volunteer events and cultural activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>150499</catValu>
+    <labl>Participating performance, cultural act., n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>150500</catValu>
+    <labl>Attending Meetings, Conferences, and Training</labl>
+  </catgry>
+  <catgry>
+    <catValu>150501</catValu>
+    <labl>Attending meetings, conferences, and training</labl>
+  </catgry>
+  <catgry>
+    <catValu>150599</catValu>
+    <labl>Attending mtgs conferences, and training, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>150600</catValu>
+    <labl>Public Health and Safety Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>150601</catValu>
+    <labl>Public health activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>150602</catValu>
+    <labl>Public safety activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>150699</catValu>
+    <labl>Public health and safety activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>150700</catValu>
+    <labl>Waiting Associated with Volunteer Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>150701</catValu>
+    <labl>Waiting associated with volunteer activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>150799</catValu>
+    <labl>Waiting assoc with volunteer activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>150800</catValu>
+    <labl>Security Procedures Related to Volunteer Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>150801</catValu>
+    <labl>Security procedures related to volunteer activities (2007+)</labl>
+  </catgry>
+  <catgry>
+    <catValu>150899</catValu>
+    <labl>Security proecdures related to voluteer activities, n.e.c. (2007+)</labl>
+  </catgry>
+  <catgry>
+    <catValu>159900</catValu>
+    <labl>Volunteer Activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>159999</catValu>
+    <labl>Volunteer activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>160000</catValu>
+    <labl>Telephone Calls</labl>
+  </catgry>
+  <catgry>
+    <catValu>160100</catValu>
+    <labl>Telephone Calls (to or from)</labl>
+  </catgry>
+  <catgry>
+    <catValu>160101</catValu>
+    <labl>Telephone calls to/from family members</labl>
+  </catgry>
+  <catgry>
+    <catValu>160102</catValu>
+    <labl>Phone calls to/from friends, neighbors</labl>
+  </catgry>
+  <catgry>
+    <catValu>160103</catValu>
+    <labl>Telephone calls to/from education svcs providers</labl>
+  </catgry>
+  <catgry>
+    <catValu>160104</catValu>
+    <labl>Telephone calls to/from salespeople</labl>
+  </catgry>
+  <catgry>
+    <catValu>160105</catValu>
+    <labl>Phone calls to/from prof, personal svcs providers</labl>
+  </catgry>
+  <catgry>
+    <catValu>160106</catValu>
+    <labl>Phone calls to/from household services providers</labl>
+  </catgry>
+  <catgry>
+    <catValu>160107</catValu>
+    <labl>Phone calls to/from child or adult care providers</labl>
+  </catgry>
+  <catgry>
+    <catValu>160108</catValu>
+    <labl>Telephone calls to/from government officials</labl>
+  </catgry>
+  <catgry>
+    <catValu>160199</catValu>
+    <labl>Telephone calls (to or from), n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>160200</catValu>
+    <labl>Waiting Associated with Telephone Calls</labl>
+  </catgry>
+  <catgry>
+    <catValu>160201</catValu>
+    <labl>Waiting associated with telephone calls</labl>
+  </catgry>
+  <catgry>
+    <catValu>160299</catValu>
+    <labl>Waiting associated with telephone calls, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>169900</catValu>
+    <labl>Telephone Calls, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>169999</catValu>
+    <labl>Telephone calls, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>180000</catValu>
+    <labl>Traveling</labl>
+  </catgry>
+  <catgry>
+    <catValu>180100</catValu>
+    <labl>Travel Related to Personal Care</labl>
+  </catgry>
+  <catgry>
+    <catValu>180101</catValu>
+    <labl>Travel related to personal care</labl>
+  </catgry>
+  <catgry>
+    <catValu>180199</catValu>
+    <labl>Travel related to personal care, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>180200</catValu>
+    <labl>Travel Related to Household Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>180201</catValu>
+    <labl>Travel related to housework</labl>
+  </catgry>
+  <catgry>
+    <catValu>180202</catValu>
+    <labl>Travel related to food and drink prep</labl>
+  </catgry>
+  <catgry>
+    <catValu>180203</catValu>
+    <labl>Travel related to int. maint, repair, and decoration</labl>
+  </catgry>
+  <catgry>
+    <catValu>180204</catValu>
+    <labl>Travel related to ext. maint, repair, and decoration</labl>
+  </catgry>
+  <catgry>
+    <catValu>180205</catValu>
+    <labl>Travel related to lawn, garden, and houseplants</labl>
+  </catgry>
+  <catgry>
+    <catValu>180206</catValu>
+    <labl>Travel related to care for animals (not vet care)</labl>
+  </catgry>
+  <catgry>
+    <catValu>180207</catValu>
+    <labl>Travel related to vehicle care and maint (by self)</labl>
+  </catgry>
+  <catgry>
+    <catValu>180208</catValu>
+    <labl>Trvl rel to app, tool, toy set-up, repair, and maint</labl>
+  </catgry>
+  <catgry>
+    <catValu>180209</catValu>
+    <labl>Travel related to household management</labl>
+  </catgry>
+  <catgry>
+    <catValu>180299</catValu>
+    <labl>Travel related to household activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>180300</catValu>
+    <labl>Travel Related to Caring for and Helping Household Members</labl>
+  </catgry>
+  <catgry>
+    <catValu>180301</catValu>
+    <labl>Travel related to caring for and helping HH children</labl>
+  </catgry>
+  <catgry>
+    <catValu>180302</catValu>
+    <labl>Travel related to caring for and helping household children (2005+)</labl>
+  </catgry>
+  <catgry>
+    <catValu>180303</catValu>
+    <labl>Travel related to hh children's education</labl>
+  </catgry>
+  <catgry>
+    <catValu>180304</catValu>
+    <labl>Travel related to hh children's health</labl>
+  </catgry>
+  <catgry>
+    <catValu>180305</catValu>
+    <labl>Travel related to caring for hh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>180306</catValu>
+    <labl>Travel related to helping hh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>180307</catValu>
+    <labl>Travel related to caring for and helping HH adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>180399</catValu>
+    <labl>Trvl rel. to caring for, helping HH members, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>180400</catValu>
+    <labl>Travel Related to Caring for and Helping Non-Household Members</labl>
+  </catgry>
+  <catgry>
+    <catValu>180401</catValu>
+    <labl>Trvl rel to caring for and helping nonHH kids, inclusive</labl>
+  </catgry>
+  <catgry>
+    <catValu>180402</catValu>
+    <labl>Trvl rel to caring for and helping nonHH kids</labl>
+  </catgry>
+  <catgry>
+    <catValu>180403</catValu>
+    <labl>Travel related to nonhh children's education</labl>
+  </catgry>
+  <catgry>
+    <catValu>180404</catValu>
+    <labl>Travel related to nonhh children's health</labl>
+  </catgry>
+  <catgry>
+    <catValu>180405</catValu>
+    <labl>Travel related to caring for nonhh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>180406</catValu>
+    <labl>Travel related to helping nonhh adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>180407</catValu>
+    <labl>Travel related to caring for, helping NonHH adults</labl>
+  </catgry>
+  <catgry>
+    <catValu>180499</catValu>
+    <labl>Trvl rel. to caring for, helping NonHH,  n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>180500</catValu>
+    <labl>Travel Related to Work</labl>
+  </catgry>
+  <catgry>
+    <catValu>180501</catValu>
+    <labl>Travel related to working</labl>
+  </catgry>
+  <catgry>
+    <catValu>180502</catValu>
+    <labl>Travel related to work-related activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>180503</catValu>
+    <labl>Travel related to income-generating activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>180504</catValu>
+    <labl>Travel related to job search and interviewing</labl>
+  </catgry>
+  <catgry>
+    <catValu>180599</catValu>
+    <labl>Travel related to work, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>180600</catValu>
+    <labl>Travel Related to Education</labl>
+  </catgry>
+  <catgry>
+    <catValu>180601</catValu>
+    <labl>Travel related to taking class</labl>
+  </catgry>
+  <catgry>
+    <catValu>180602</catValu>
+    <labl>Trvl rel to extracurricular activities (ex. Sports)</labl>
+  </catgry>
+  <catgry>
+    <catValu>180603</catValu>
+    <labl>Travel related to research/homework</labl>
+  </catgry>
+  <catgry>
+    <catValu>180604</catValu>
+    <labl>Travel related to registration/admin activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>180605</catValu>
+    <labl>Education-related travel, not commuting</labl>
+  </catgry>
+  <catgry>
+    <catValu>180699</catValu>
+    <labl>Education travel, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>180700</catValu>
+    <labl>Travel Related to Consumer Purchases</labl>
+  </catgry>
+  <catgry>
+    <catValu>180701</catValu>
+    <labl>Traveling to/from the grocery store</labl>
+  </catgry>
+  <catgry>
+    <catValu>180702</catValu>
+    <labl>Travel related to other shopping</labl>
+  </catgry>
+  <catgry>
+    <catValu>180703</catValu>
+    <labl>Travel related to purchasing food (not groceries)</labl>
+  </catgry>
+  <catgry>
+    <catValu>180704</catValu>
+    <labl>Travel related to shopping, ex groc, food, gas</labl>
+  </catgry>
+  <catgry>
+    <catValu>180705</catValu>
+    <labl>Traveling to/from gas station</labl>
+  </catgry>
+  <catgry>
+    <catValu>180799</catValu>
+    <labl>Travel related to consumer purchases, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>180800</catValu>
+    <labl>Travel Related to Using Professional and Personal Care Services</labl>
+  </catgry>
+  <catgry>
+    <catValu>180801</catValu>
+    <labl>Travel related to using childcare services</labl>
+  </catgry>
+  <catgry>
+    <catValu>180802</catValu>
+    <labl>Travel related to using financial svcs and banking</labl>
+  </catgry>
+  <catgry>
+    <catValu>180803</catValu>
+    <labl>Travel related to using legal services</labl>
+  </catgry>
+  <catgry>
+    <catValu>180804</catValu>
+    <labl>Travel related to using medical services</labl>
+  </catgry>
+  <catgry>
+    <catValu>180805</catValu>
+    <labl>Travel related to using personal care services</labl>
+  </catgry>
+  <catgry>
+    <catValu>180806</catValu>
+    <labl>Travel related to using real estate services</labl>
+  </catgry>
+  <catgry>
+    <catValu>180807</catValu>
+    <labl>Travel related to using veterinary services</labl>
+  </catgry>
+  <catgry>
+    <catValu>180899</catValu>
+    <labl>Travel rel. to using prof, personal care svcs n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>180900</catValu>
+    <labl>Travel Related to Using Household Services</labl>
+  </catgry>
+  <catgry>
+    <catValu>180901</catValu>
+    <labl>Travel related to using household services</labl>
+  </catgry>
+  <catgry>
+    <catValu>180902</catValu>
+    <labl>Trvl rel to using home maint etc svcs</labl>
+  </catgry>
+  <catgry>
+    <catValu>180903</catValu>
+    <labl>Travel related to using pet services (not vet)</labl>
+  </catgry>
+  <catgry>
+    <catValu>180904</catValu>
+    <labl>Travel related to using lawn and garden services</labl>
+  </catgry>
+  <catgry>
+    <catValu>180905</catValu>
+    <labl>Trvl rel to using vehicle maint and repair services</labl>
+  </catgry>
+  <catgry>
+    <catValu>180999</catValu>
+    <labl>Travel related to using household services, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>181000</catValu>
+    <labl>Travel Related to Using Government Services and Civic Obligations</labl>
+  </catgry>
+  <catgry>
+    <catValu>181001</catValu>
+    <labl>Travel related to using government services</labl>
+  </catgry>
+  <catgry>
+    <catValu>181002</catValu>
+    <labl>Travel related to civic obligations and participation</labl>
+  </catgry>
+  <catgry>
+    <catValu>181099</catValu>
+    <labl>Travel rel. to govt svcs and civic obligations, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>181100</catValu>
+    <labl>Travel Related to Eating and Drinking</labl>
+  </catgry>
+  <catgry>
+    <catValu>181101</catValu>
+    <labl>Travel related to eating and drinking</labl>
+  </catgry>
+  <catgry>
+    <catValu>181199</catValu>
+    <labl>Travel related to eating and drinking, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>181200</catValu>
+    <labl>Travel Related to Socializing, Relaxing, and Leisure</labl>
+  </catgry>
+  <catgry>
+    <catValu>181201</catValu>
+    <labl>Travel related to socializing and communicating</labl>
+  </catgry>
+  <catgry>
+    <catValu>181202</catValu>
+    <labl>Trvl related to attending or hosting social events</labl>
+  </catgry>
+  <catgry>
+    <catValu>181203</catValu>
+    <labl>Travel related to relaxing and leisure (2003, 2004)</labl>
+  </catgry>
+  <catgry>
+    <catValu>181204</catValu>
+    <labl>Travel related to arts and entertainment</labl>
+  </catgry>
+  <catgry>
+    <catValu>181205</catValu>
+    <labl>Travel as a form of entertainment</labl>
+  </catgry>
+  <catgry>
+    <catValu>181206</catValu>
+    <labl>Travel related to relaxing and leisure (2005+)</labl>
+  </catgry>
+  <catgry>
+    <catValu>181299</catValu>
+    <labl>Travel rel. to socializing, relaxing, leisure, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>181300</catValu>
+    <labl>Travel Related to Sports, Exercise, and Recreation</labl>
+  </catgry>
+  <catgry>
+    <catValu>181301</catValu>
+    <labl>Trvl rel to doing sports/exercise/recreation</labl>
+  </catgry>
+  <catgry>
+    <catValu>181302</catValu>
+    <labl>Trvl rel to attending sporting/recreational events</labl>
+  </catgry>
+  <catgry>
+    <catValu>181399</catValu>
+    <labl>Travel rel to sports, exercise, recreation, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>181400</catValu>
+    <labl>Travel Related to Religious or Spiritual Activities</labl>
+  </catgry>
+  <catgry>
+    <catValu>181401</catValu>
+    <labl>Travel related to religious/spiritual practices</labl>
+  </catgry>
+  <catgry>
+    <catValu>181499</catValu>
+    <labl>Travel rel. to religious/spiritual activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>181500</catValu>
+    <labl>Travel Related to Volunteering</labl>
+  </catgry>
+  <catgry>
+    <catValu>181501</catValu>
+    <labl>Travel related to volunteering</labl>
+  </catgry>
+  <catgry>
+    <catValu>181599</catValu>
+    <labl>Travel related to volunteer activities, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>181600</catValu>
+    <labl>Travel Related to Phone Calls</labl>
+  </catgry>
+  <catgry>
+    <catValu>181601</catValu>
+    <labl>Travel related to phone calls</labl>
+  </catgry>
+  <catgry>
+    <catValu>181699</catValu>
+    <labl>Travel rel. to phone calls, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>181800</catValu>
+    <labl>Security Procedures Related to Traveling</labl>
+  </catgry>
+  <catgry>
+    <catValu>181801</catValu>
+    <labl>Security procedures related to traveling</labl>
+  </catgry>
+  <catgry>
+    <catValu>181899</catValu>
+    <labl>Security procedures related to traveling, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>189900</catValu>
+    <labl>Traveling, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>189999</catValu>
+    <labl>Traveling, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>500000</catValu>
+    <labl>Data Codes</labl>
+  </catgry>
+  <catgry>
+    <catValu>500100</catValu>
+    <labl>Unable to Code</labl>
+  </catgry>
+  <catgry>
+    <catValu>500101</catValu>
+    <labl>Insufficient detail in verbatim</labl>
+  </catgry>
+  <catgry>
+    <catValu>500102</catValu>
+    <labl>Recorded activity using incorrect words</labl>
+  </catgry>
+  <catgry>
+    <catValu>500103</catValu>
+    <labl>Missing travel or destination</labl>
+  </catgry>
+  <catgry>
+    <catValu>500104</catValu>
+    <labl>Recorded simultaneous activities incorrectly</labl>
+  </catgry>
+  <catgry>
+    <catValu>500105</catValu>
+    <labl>Respondent refused to provide information</labl>
+  </catgry>
+  <catgry>
+    <catValu>500106</catValu>
+    <labl>Gap/can't remember</labl>
+  </catgry>
+  <catgry>
+    <catValu>500107</catValu>
+    <labl>Unable to code activity at 1st tier</labl>
+  </catgry>
+  <catgry>
+    <catValu>509900</catValu>
+    <labl>Data codes, n.e.c.</labl>
+  </catgry>
+  <catgry>
+    <catValu>509999</catValu>
+    <labl>Data codes, n.e.c.</labl>
+  </catgry>
+  <concept vocab="IPUMS">Technical Activity Variables -- ACTIVITY</concept>
+  <varFormat schema="other" type="numeric"/>
+</var>
+<var ID="WHERE" dcml="0" files="ExtractData" intrvl="discrete" name="WHERE" rectype="3">
+  <location EndPos="39" StartPos="36" width="4"/>
+  <labl>Location of activity</labl>
+  <txt><![CDATA[WHERE reports the location of the activity.
+
+WHERE is recorded for all activities except sleeping (0101xx), grooming (0102xx), personal activities (0104xx), "respondent refused to answer" (500105), and "respondent didn't remember" (500106).
+
+This variable is available via extracts that are hierarchical or rectangular (activity) (more info on extract formats). If you request a hierarchical extract and plan to construct time use variables in your statistics package, this variable may be useful to you. If you request a rectangular extract and plan to construct time use variables through the extract system, WHERE will not be included in your extract, as persons are the unit of observation for rectangular extracts rather than activity or who records.]]></txt>
+  <catgry>
+    <catValu>0100</catValu>
+    <labl>Place</labl>
+  </catgry>
+  <catgry>
+    <catValu>0101</catValu>
+    <labl>R's home or yard</labl>
+  </catgry>
+  <catgry>
+    <catValu>0102</catValu>
+    <labl>R's workplace</labl>
+  </catgry>
+  <catgry>
+    <catValu>0103</catValu>
+    <labl>Someone else's home</labl>
+  </catgry>
+  <catgry>
+    <catValu>0104</catValu>
+    <labl>Restaurant or bar</labl>
+  </catgry>
+  <catgry>
+    <catValu>0105</catValu>
+    <labl>Place of worship</labl>
+  </catgry>
+  <catgry>
+    <catValu>0106</catValu>
+    <labl>Grocery store</labl>
+  </catgry>
+  <catgry>
+    <catValu>0107</catValu>
+    <labl>Other store/mall</labl>
+  </catgry>
+  <catgry>
+    <catValu>0108</catValu>
+    <labl>School</labl>
+  </catgry>
+  <catgry>
+    <catValu>0109</catValu>
+    <labl>Outdoors--not at home</labl>
+  </catgry>
+  <catgry>
+    <catValu>0110</catValu>
+    <labl>Library</labl>
+  </catgry>
+  <catgry>
+    <catValu>0111</catValu>
+    <labl>Bank</labl>
+  </catgry>
+  <catgry>
+    <catValu>0112</catValu>
+    <labl>Gym/health club</labl>
+  </catgry>
+  <catgry>
+    <catValu>0113</catValu>
+    <labl>Post Office</labl>
+  </catgry>
+  <catgry>
+    <catValu>0114</catValu>
+    <labl>Other place</labl>
+  </catgry>
+  <catgry>
+    <catValu>0115</catValu>
+    <labl>Unspecified place</labl>
+  </catgry>
+  <catgry>
+    <catValu>0200</catValu>
+    <labl>Mode of Transportation</labl>
+  </catgry>
+  <catgry>
+    <catValu>0230</catValu>
+    <labl>Driver of car, truck, or motorcycle</labl>
+  </catgry>
+  <catgry>
+    <catValu>0231</catValu>
+    <labl>Passenger of car, truck, or motorcycle</labl>
+  </catgry>
+  <catgry>
+    <catValu>0232</catValu>
+    <labl>Walking</labl>
+  </catgry>
+  <catgry>
+    <catValu>0233</catValu>
+    <labl>Bus</labl>
+  </catgry>
+  <catgry>
+    <catValu>0234</catValu>
+    <labl>Subway/train</labl>
+  </catgry>
+  <catgry>
+    <catValu>0235</catValu>
+    <labl>Bicycle</labl>
+  </catgry>
+  <catgry>
+    <catValu>0236</catValu>
+    <labl>Boat/ferry</labl>
+  </catgry>
+  <catgry>
+    <catValu>0237</catValu>
+    <labl>Taxi/limousine service</labl>
+  </catgry>
+  <catgry>
+    <catValu>0238</catValu>
+    <labl>Airplane</labl>
+  </catgry>
+  <catgry>
+    <catValu>0239</catValu>
+    <labl>Other mode of transportation</labl>
+  </catgry>
+  <catgry>
+    <catValu>0240</catValu>
+    <labl>Unspecified mode of transportation</labl>
+  </catgry>
+  <catgry>
+    <catValu>9997</catValu>
+    <labl>Don't know</labl>
+  </catgry>
+  <catgry>
+    <catValu>9998</catValu>
+    <labl>Refused</labl>
+  </catgry>
+  <catgry>
+    <catValu>9999</catValu>
+    <labl>NIU (Not in universe)</labl>
+  </catgry>
+  <concept vocab="IPUMS">Technical Activity Variables -- ACTIVITY</concept>
+  <varFormat schema="other" type="numeric"/>
+</var>
+<var ID="ACTLINEW" dcml="0" files="ExtractData" intrvl="contin" name="ACTLINEW" rectype="4">
+  <location EndPos="29" StartPos="28" width="2"/>
+  <labl>Activity line number</labl>
+  <txt><![CDATA[ACTLINEW indicates the line number of the activity to which the who record corresponds. Because the ATUS respondent may have reported more than one person who was present during the activity, multiple who records may correspond to the same activity.
+
+ACTLINEW is available only if you select a hierarchical extract. If you request a hierarchical extract and plan to construct time use variables in your statistics package, this variable may be useful to you. If you request a rectangular extract and plan to construct time use variables through the extract system, ACTLINEW will not be included in your extract, as persons are the unit of observation for rectangular extracts rather than activity or who records.]]></txt>
+  <codInstr><![CDATA[This is a 2-digit numeric variable with 0 implied decimal places]]></codInstr>
+  <concept vocab="IPUMS">Technical Who Variables -- WHO</concept>
+  <varFormat schema="other" type="numeric"/>
+</var>
+<var ID="RELATEW" dcml="0" files="ExtractData" intrvl="discrete" name="RELATEW" rectype="4">
+  <location EndPos="33" StartPos="30" width="4"/>
+  <labl>Relationship of person with whom activity was done</labl>
+  <txt><![CDATA[RELATEW reports the relationship to the respondent of the individual with whom the activity was performed. Users should note that "who" information is not collected for all activities (see WHO_ASK).
+
+RELATEW is available only if you select a hierarchical extract. If you request a hierarchical extract and plan to construct time use variables in your statistics package, this variable may be useful to you. If you request a rectangular extract and plan to construct time use variables through the extract system, RELATEW will not be included in your extract, as persons are the unit of observation for rectangular extracts rather than activity or who records.]]></txt>
+  <catgry>
+    <catValu>0100</catValu>
+    <labl>Alone</labl>
+  </catgry>
+  <catgry>
+    <catValu>0200</catValu>
+    <labl>Spouse</labl>
+  </catgry>
+  <catgry>
+    <catValu>0201</catValu>
+    <labl>Unmarried partner</labl>
+  </catgry>
+  <catgry>
+    <catValu>0202</catValu>
+    <labl>Own household child</labl>
+  </catgry>
+  <catgry>
+    <catValu>0203</catValu>
+    <labl>Grandchild</labl>
+  </catgry>
+  <catgry>
+    <catValu>0204</catValu>
+    <labl>Parent</labl>
+  </catgry>
+  <catgry>
+    <catValu>0205</catValu>
+    <labl>Brother sister</labl>
+  </catgry>
+  <catgry>
+    <catValu>0206</catValu>
+    <labl>Other related person</labl>
+  </catgry>
+  <catgry>
+    <catValu>0207</catValu>
+    <labl>Foster child</labl>
+  </catgry>
+  <catgry>
+    <catValu>0208</catValu>
+    <labl>Housemate, roommate</labl>
+  </catgry>
+  <catgry>
+    <catValu>0209</catValu>
+    <labl>Roomer, boarder</labl>
+  </catgry>
+  <catgry>
+    <catValu>0210</catValu>
+    <labl>Other nonrelative</labl>
+  </catgry>
+  <catgry>
+    <catValu>0300</catValu>
+    <labl>Own non-household child under 18</labl>
+  </catgry>
+  <catgry>
+    <catValu>0400</catValu>
+    <labl>Parents (not living in household)</labl>
+  </catgry>
+  <catgry>
+    <catValu>0401</catValu>
+    <labl>Other non-household family members under 18</labl>
+  </catgry>
+  <catgry>
+    <catValu>0402</catValu>
+    <labl>Other non-household family members 18 and older (including parents-in-law)</labl>
+  </catgry>
+  <catgry>
+    <catValu>0403</catValu>
+    <labl>Friends</labl>
+  </catgry>
+  <catgry>
+    <catValu>0404</catValu>
+    <labl>Co-workers, colleagues, clients (non-work activities only)</labl>
+  </catgry>
+  <catgry>
+    <catValu>0405</catValu>
+    <labl>Neighbors, acquaintances</labl>
+  </catgry>
+  <catgry>
+    <catValu>0406</catValu>
+    <labl>Other non-household children under 18</labl>
+  </catgry>
+  <catgry>
+    <catValu>0407</catValu>
+    <labl>Other non-household adults 18 and older</labl>
+  </catgry>
+  <catgry>
+    <catValu>0408</catValu>
+    <labl>Boss or manager (work activities only, 2010+)</labl>
+  </catgry>
+  <catgry>
+    <catValu>0409</catValu>
+    <labl>People whom I supervise (work activities only, 2010+)</labl>
+  </catgry>
+  <catgry>
+    <catValu>0410</catValu>
+    <labl>Co-workers (work activities only, 2010+)</labl>
+  </catgry>
+  <catgry>
+    <catValu>0411</catValu>
+    <labl>Customers (work activities only, 2010+)</labl>
+  </catgry>
+  <catgry>
+    <catValu>9996</catValu>
+    <labl>Refused</labl>
+  </catgry>
+  <catgry>
+    <catValu>9997</catValu>
+    <labl>Don't know</labl>
+  </catgry>
+  <catgry>
+    <catValu>9998</catValu>
+    <labl>Blank</labl>
+  </catgry>
+  <concept vocab="IPUMS">Technical Who Variables -- WHO</concept>
+  <varFormat schema="other" type="numeric"/>
+</var>
+</dataDscr>
+</codeBook>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -158,44 +158,56 @@ def test_usa_build_extract():
         "version": None,
     }
 
+
 def test_mtus_build_extract():
     """Make sure unsuported attachCharacteristics elements are removed"""
     extract = MicrodataExtract(
         collection="mtus",
         description="API testing",
         samples=["us2023a"],
-        variables=["SEX","AGE","EMPINCLM","CLOCKST"],
+        variables=["SEX", "AGE", "EMPINCLM", "CLOCKST"],
         time_use_variables=["ACT_PCARE", "ACT_NOREC"],
         data_structure={"hierarchical": {}},
-        data_format="fixed_width"
+        data_format="fixed_width",
     )
-    
+
     assert extract.build() == {
-        'description': 'API testing',
-        'dataFormat': 'fixed_width',
-        'dataStructure': {'hierarchical': {}},
-        'samples': {'us2023a': {}},
-        'variables': {'SEX': {'preselected': False,
-        'caseSelections': {},
-        'dataQualityFlags': False,
-        'adjustMonetaryValues': False},
-        'AGE': {'preselected': False,
-        'caseSelections': {},
-        'dataQualityFlags': False,
-        'adjustMonetaryValues': False},
-        'EMPINCLM': {'preselected': False,
-        'caseSelections': {},
-        'dataQualityFlags': False,
-        'adjustMonetaryValues': False},
-        'CLOCKST': {'preselected': False,
-        'caseSelections': {},
-        'dataQualityFlags': False,
-        'adjustMonetaryValues': False}},
-        'collection': 'mtus',
-        'version': None,
-        'timeUseVariables': {'ACT_PCARE': {}, 'ACT_NOREC': {}}
+        "description": "API testing",
+        "dataFormat": "fixed_width",
+        "dataStructure": {"hierarchical": {}},
+        "samples": {"us2023a": {}},
+        "variables": {
+            "SEX": {
+                "preselected": False,
+                "caseSelections": {},
+                "dataQualityFlags": False,
+                "adjustMonetaryValues": False,
+            },
+            "AGE": {
+                "preselected": False,
+                "caseSelections": {},
+                "dataQualityFlags": False,
+                "adjustMonetaryValues": False,
+            },
+            "EMPINCLM": {
+                "preselected": False,
+                "caseSelections": {},
+                "dataQualityFlags": False,
+                "adjustMonetaryValues": False,
+            },
+            "CLOCKST": {
+                "preselected": False,
+                "caseSelections": {},
+                "dataQualityFlags": False,
+                "adjustMonetaryValues": False,
+            },
+        },
+        "collection": "mtus",
+        "version": None,
+        "timeUseVariables": {"ACT_PCARE": {}, "ACT_NOREC": {}},
     }
-    
+
+
 def test_usa_attach_characteristics():
     """
     Confirm that attach_characteristics updates extract definition correctly
@@ -1930,5 +1942,3 @@ def test_adjust_monetary_values_errors(live_api_client: IpumsApiClient):
         exc_info.value.args[0]
         == "Monetary value adjustment is not supported for IPUMS ATUS"
     )
-
-    

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -158,7 +158,44 @@ def test_usa_build_extract():
         "version": None,
     }
 
-
+def test_mtus_build_extract():
+    """Make sure unsuported attachCharacteristics elements are removed"""
+    extract = MicrodataExtract(
+        collection="mtus",
+        description="API testing",
+        samples=["us2023a"],
+        variables=["SEX","AGE","EMPINCLM","CLOCKST"],
+        time_use_variables=["ACT_PCARE", "ACT_NOREC"],
+        data_structure={"hierarchical": {}},
+        data_format="fixed_width"
+    )
+    
+    assert extract.build() == {
+        'description': 'API testing',
+        'dataFormat': 'fixed_width',
+        'dataStructure': {'hierarchical': {}},
+        'samples': {'us2023a': {}},
+        'variables': {'SEX': {'preselected': False,
+        'caseSelections': {},
+        'dataQualityFlags': False,
+        'adjustMonetaryValues': False},
+        'AGE': {'preselected': False,
+        'caseSelections': {},
+        'dataQualityFlags': False,
+        'adjustMonetaryValues': False},
+        'EMPINCLM': {'preselected': False,
+        'caseSelections': {},
+        'dataQualityFlags': False,
+        'adjustMonetaryValues': False},
+        'CLOCKST': {'preselected': False,
+        'caseSelections': {},
+        'dataQualityFlags': False,
+        'adjustMonetaryValues': False}},
+        'collection': 'mtus',
+        'version': None,
+        'timeUseVariables': {'ACT_PCARE': {}, 'ACT_NOREC': {}}
+    }
+    
 def test_usa_attach_characteristics():
     """
     Confirm that attach_characteristics updates extract definition correctly
@@ -1893,3 +1930,5 @@ def test_adjust_monetary_values_errors(live_api_client: IpumsApiClient):
         exc_info.value.args[0]
         == "Monetary value adjustment is not supported for IPUMS ATUS"
     )
+
+    

--- a/tests/test_ddi.py
+++ b/tests/test_ddi.py
@@ -116,7 +116,7 @@ def test_get_variable_info_hierarchical(cps_ddi_hierarchical: ddi.Codebook):
     # And does it raise a ValueError if the variable does not exist?
     with pytest.raises(ValueError):
         cps_ddi_hierarchical.get_variable_info("foo")
-        
+
 
 def test_ddi_codebook_rectangular(cps_ddi: ddi.Codebook):
     # sample descriptions/names
@@ -274,14 +274,12 @@ def test_ddi_codebook_hierarchical(cps_ddi_hierarchical: ddi.Codebook):
         "\n"
         "(4) Use it for GOOD -- never for EVIL."
     )
-    
-    
+
+
 def test_complex_ddi_codebook_hierarchical(atus_ddi_hierarchical: ddi.Codebook):
     """Test ddi with more than two record types"""
     # sample descriptions/names
-    assert atus_ddi_hierarchical.samples_description == [
-        "ATUS 2024"
-    ]
+    assert atus_ddi_hierarchical.samples_description == ["ATUS 2024"]
 
     # doi
     assert atus_ddi_hierarchical.ipums_doi == "DOI:10.18128/D060.V3.3"
@@ -293,7 +291,7 @@ def test_complex_ddi_codebook_hierarchical(atus_ddi_hierarchical: ddi.Codebook):
     assert atus_ddi_hierarchical.file_description.structure == "hierarchical"
 
     # rectypes
-    assert atus_ddi_hierarchical.file_description.rectypes == ['1', '2', '3', '4']
+    assert atus_ddi_hierarchical.file_description.rectypes == ["1", "2", "3", "4"]
 
     # rectype idvar
     assert atus_ddi_hierarchical.file_description.rectype_idvar == "RECTYPE"

--- a/tests/test_ddi.py
+++ b/tests/test_ddi.py
@@ -32,10 +32,10 @@ def cps_ddi_hierarchical(fixtures_path: Path) -> ddi.Codebook:
     return readers.read_ipums_ddi(fixtures_path / "cps_00421.xml")
 
 
-# not implemented yet
-# @pytest.fixture(scope="function")
-# def cps_df_hierarchical(fixtures_path: Path, cps_ddi_hierarchical: ddi.Codebook) -> pd.DataFrame:
-#     return readers.read_microdata(cps_ddi_hierarchical, fixtures_path / "cps_00421.dat.gz")
+@pytest.fixture(scope="function")
+def atus_ddi_hierarchical(fixtures_path: Path) -> ddi.Codebook:
+    """DDI with rectypes in order of hierarchy"""
+    return readers.read_ipums_ddi(fixtures_path / "atus_00040.xml")
 
 
 def test_get_variable_info_rectangular(cps_ddi: ddi.Codebook):
@@ -116,7 +116,7 @@ def test_get_variable_info_hierarchical(cps_ddi_hierarchical: ddi.Codebook):
     # And does it raise a ValueError if the variable does not exist?
     with pytest.raises(ValueError):
         cps_ddi_hierarchical.get_variable_info("foo")
-
+        
 
 def test_ddi_codebook_rectangular(cps_ddi: ddi.Codebook):
     # sample descriptions/names
@@ -271,6 +271,83 @@ def test_ddi_codebook_hierarchical(cps_ddi_hierarchical: ddi.Codebook):
         "funding for the IPUMS depends on our ability "
         "to  show our sponsor agencies that researchers "
         "are using the data for productive  purposes.\n"
+        "\n"
+        "(4) Use it for GOOD -- never for EVIL."
+    )
+    
+    
+def test_complex_ddi_codebook_hierarchical(atus_ddi_hierarchical: ddi.Codebook):
+    """Test ddi with more than two record types"""
+    # sample descriptions/names
+    assert atus_ddi_hierarchical.samples_description == [
+        "ATUS 2024"
+    ]
+
+    # doi
+    assert atus_ddi_hierarchical.ipums_doi == "DOI:10.18128/D060.V3.3"
+
+    # data format
+    assert atus_ddi_hierarchical.file_description.format == "fixed length fields"
+
+    # data structure
+    assert atus_ddi_hierarchical.file_description.structure == "hierarchical"
+
+    # rectypes
+    assert atus_ddi_hierarchical.file_description.rectypes == ['1', '2', '3', '4']
+
+    # rectype idvar
+    assert atus_ddi_hierarchical.file_description.rectype_idvar == "RECTYPE"
+
+    # rectype keyvar
+    assert atus_ddi_hierarchical.file_description.rectype_keyvar == "CASEID"
+
+    # data collection
+    assert atus_ddi_hierarchical.ipums_collection == "atus"
+
+    # citation
+    assert atus_ddi_hierarchical.ipums_citation == (
+        "Publications and research reports based on the "
+        "ATUS database must cite it appropriately. "
+        "The citation should include the following:\n"
+        "\n"
+        "Sarah M. Flood, Liana C. Sayer, and Daniel Backman. "
+        "American Time Use Survey Data Extract Builder: Version 3.3 [dataset]. "
+        "College Park, MD: University of Maryland and Minneapolis, MN: IPUMS, 2025. "
+        "https://doi.org/10.18128/D060.V3.3\n"
+        "\n"
+        "The licensing agreement for use of ATUS "
+        "data requires that users supply us with the "
+        "title and full citation for any publications, "
+        "research reports, or educational materials "
+        "making use of the data or documentation. Please "
+        "add your citation to the IPUMS bibliography: "
+        "http://bibliography.ipums.org/"
+    )
+
+    # terms of use
+    assert atus_ddi_hierarchical.ipums_conditions == (
+        "Users of ATUS data must agree to abide by "
+        "the conditions of use. A user's license is "
+        "valid for one year and may be renewed.  Users "
+        "must agree to the following conditions:\n"
+        "\n"
+        "(1) No fees may be charged for use or "
+        "distribution of the data.  All persons are "
+        "granted a limited license to use these data, "
+        "but you may not charge a fee for the data if "
+        "you distribute it to others.\n"
+        "\n"
+        "(2) Cite IPUMS appropriately.  For information "
+        "on proper citation, refer to the citation "
+        "requirement section of this DDI document.\n"
+        "\n"
+        "(3) Tell us about any work you do using the "
+        "IPUMS.  Publications, research reports, or "
+        "presentations making use of ATUS should "
+        "be added to our Bibliography. Continued "
+        "funding for the IPUMS depends on our ability "
+        "to show our sponsor agencies that researchers "
+        "are using the data for productive purposes.\n"
         "\n"
         "(4) Use it for GOOD -- never for EVIL."
     )


### PR DESCRIPTION
This release corrects two bugs:

1. MTUS and AHTUS collections do not support attach characteristics; this release ensures that their extract definitions do not contain empty `attachCharacteristics` elements.

2. A change to DDI files for hierarchical extracts is now accomodated by the `readers.read_ipums_ddi()`